### PR TITLE
Define HBE Buyer Platform operating structure

### DIFF
--- a/docs/buyer-platform/ARCHITECTURE.md
+++ b/docs/buyer-platform/ARCHITECTURE.md
@@ -1,0 +1,70 @@
+# HBE Buyer Platform Architecture
+
+## Target model
+One platform, many humans.
+
+`/buyers/<buyer-id>/` should load a shared BuyerUI application and then load/decrypt that buyer's data. A buyer should not become a fork of the application.
+
+## Proposed layers
+
+### 1. Buyer data layer
+Contains buyer-specific state only:
+- stable buyer ID
+- display name and login identity
+- encrypted profile/discovery answers
+- current stage and completed stages
+- stage summaries and HBE status
+- buyer WHY
+- ideal-home sketch reference
+- property/debrief records
+- photo annotations and information requests
+- communication preferences and links
+
+This data must survive every UI deployment unchanged unless an intentional data migration is required.
+
+### 2. Shared BuyerUI layer
+Contains behavior and presentation shared by every buyer:
+- authentication shell
+- roadmap stage definitions
+- trail geometry and checkpoint sketches
+- locked/current/completed visual states
+- hover expectation bubbles
+- HBE activity/status bubble
+- stage dialogs/pages
+- texting/communication launcher
+- release watcher
+- accessibility/responsive behavior
+
+### 3. Shared HBEUI layer
+Contains advisor-facing workflow:
+- Active Human Engagement dashboard
+- New Form Submissions
+- Active Consults
+- Humans Hunting for Their Treasure
+- Successful Hunts
+- human profile/advisor roadmap
+- consultation brief
+- post-interaction capture
+- task/status controls
+- reversible breadcrumb navigation
+
+HBE actions can produce buyer-facing status, but internal notes must not leak into BuyerUI.
+
+### 4. Deployment/release layer
+Owns:
+- preview build per branch/PR
+- production deploy from approved main
+- release identifier
+- cache invalidation
+- active-session upgrade detection
+- deployment verification
+- rollback
+
+## State contract
+UI code reads buyer state; it does not redefine buyer state. Stage IDs must be stable. Human-readable labels may evolve without invalidating stored progress.
+
+Recommended stable stage IDs:
+`headquarters`, `buyerDiscovery`, `consultation`, `representation`, `search`, `market`, `possibilities`, `evaluation`, `offer`, `terms`, `negotiation`, `diligence`, `inspection`, `value`, `loan`, `commitment`, `closing`.
+
+## Buyer safety rule
+When code changes, the default behavior is preserve existing buyer state and render it with the newest compatible UI. If a release requires a state migration, it must be explicit, tested, reversible and documented.

--- a/docs/buyer-platform/DELIVERY.md
+++ b/docs/buyer-platform/DELIVERY.md
@@ -1,0 +1,57 @@
+# Buyer Platform Delivery Contract
+
+## Environments
+
+### Preview
+Every proposed UI change must have a browser-usable preview before production merge.
+
+Required properties:
+- built from the exact branch/commit under review
+- URL is deterministic and reported by CI/deployment tooling
+- visibly marked PREVIEW / NOT LIVE
+- loads buyer fixture/test data, never a real buyer secret by default
+- displays commit SHA or release ID somewhere unobtrusive for verification
+- can exercise authentication, roadmap interactions, hover states and responsive behavior
+
+Do not tell a reviewer a preview is ready until the preview URL returns successfully.
+
+### Production
+Production deploys only from approved `main`.
+
+A merge is not a deployment. A deployment is not complete until the public production URL is verified to serve the expected release.
+
+## Required publish sequence
+1. Build/test branch.
+2. Deploy preview.
+3. Verify preview URL and expected commit.
+4. Human approval.
+5. Merge to `main`.
+6. Generate/increment release ID automatically.
+7. Deploy production.
+8. Verify production URL reports expected release.
+9. Only then report LIVE.
+
+## Release/version rule
+There must be one source of truth for the BuyerUI release ID. Shared CSS/JS asset URLs derive from that ID automatically. Do not manually maintain independent cache-buster strings.
+
+## Active buyer upgrade rule
+An already-open BuyerUI periodically checks the production release manifest and also checks on focus/visibility return. When a compatible newer release exists, it reloads using that release ID. Buyer state remains independent of UI release.
+
+## Rollback
+Keep the last known-good production artifact/release addressable. Rollback changes the active production release to that artifact; it must not roll back buyer data.
+
+## Deployment verification
+Minimum verification:
+- URL returns 200
+- page identifies expected release/commit
+- shared CSS and JS return successfully
+- exercise buyer can authenticate
+- encrypted profile loads
+- roadmap renders
+- hover bubbles work for available and locked stops
+- current/completed/locked states are distinguishable
+- communication launcher resolves correctly
+- no critical console/load errors
+
+## Preview infrastructure decision
+Forge must first inspect the repository/hosting configuration and choose an implementation that can actually produce branch/PR preview URLs. Candidate approaches include a GitHub Actions preview deployment, a dedicated preview host, or another static hosting provider with preview deployments. Do not assume GitHub Pages publishes arbitrary branches or newly committed files until the repository's Pages source/deployment configuration is confirmed.

--- a/docs/buyer-platform/FORGE_IMPLEMENTATION_PLAN.md
+++ b/docs/buyer-platform/FORGE_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,111 @@
+# Forge Implementation Plan
+
+## Mission
+Make HBE BuyerUI/HBEUI safe and fast to evolve while humans are actively using it.
+
+Do not expand HBEUI feature depth until Phase 1 is working. BuyerUI platform reliability is the gate.
+
+## Phase 0 - Discover the actual hosting contract
+Before writing deployment code, determine and record:
+- repository default branch
+- GitHub Pages source/configuration, if Pages is the production host
+- whether Pages is branch-based or Actions-based
+- actual production publish path (`static/`, root, generated output, etc.)
+- DNS/custom-domain behavior if any
+- existing CI/CD hooks outside `.github/workflows`
+- whether a preview host/service already exists
+
+Deliverable: `docs/buyer-platform/HOSTING.md` with facts, not assumptions.
+
+## Phase 1 - Reliable preview pipeline
+Build a preview system that produces a verified browser URL from a PR/branch.
+
+Acceptance:
+- change shared BuyerUI CSS on a branch
+- preview deploy starts automatically or through one documented command/action
+- preview URL is discoverable
+- HTTP verification passes
+- page exposes commit SHA
+- production remains unchanged
+- Chris can open and interact with Donald exercise preview
+
+Only after this passes should proposed visual changes use preview approval.
+
+## Phase 2 - One release source of truth
+Replace scattered manual asset versions with one generated release ID.
+
+Acceptance:
+- HTML/shared assets derive cache version from same release
+- release manifest is generated/updated as part of production publish
+- no developer has to remember to edit `?v=` values
+- an active exercise session detects a new release and loads new CSS/JS without manual cache clearing
+
+## Phase 3 - Shared BuyerUI template
+Refactor buyer pages so buyer-specific files contain data/config, not copied application markup/logic.
+
+Target conceptual structure:
+```
+static/
+  buyer-portal/
+    app/
+      index.html
+      buyerui.js
+      buyerui.css
+      roadmap.js
+      checkpoint-sketches.js
+      communications.js
+      release.js
+    buyers/
+      <buyer-id>/
+        profile.enc.json
+        public-config.json
+```
+Exact paths may differ after repo inspection.
+
+Acceptance:
+- Donald and a second fixture buyer use the same app code
+- changing one shared component changes both previews
+- buyer-specific state stays isolated
+- stable stage IDs preserve progress
+
+## Phase 4 - Deployment verification and rollback
+Automate smoke tests after preview and production deploy.
+
+Acceptance:
+- failed verification prevents a LIVE claim
+- release/commit can be read from deployed page
+- previous known-good UI release can be restored without touching buyer data
+
+## Phase 5 - HBEUI foundation
+Then implement the advisor hierarchy:
+`Active Human Engagement -> Engagement Group -> Human -> Advisor Roadmap -> Task`
+
+Groups:
+1. New Form Submissions
+2. Active Consults
+3. Humans Hunting for Their Treasure
+4. Successful Hunts
+
+Every deeper screen gets reversible breadcrumbs/back navigation. HBE internal state and buyer-visible status are separate fields.
+
+## Phase 6 - Interaction synchronization
+Wire HBE actions to BuyerUI progression deliberately:
+- form submitted -> HBE new submission
+- HBE reviews -> buyer-facing status
+- consultation completed/captured -> next buyer stop becomes available
+- Hire HBE/agency agreement -> represented/search workflow
+- showing/property evaluation -> post-appointment debrief
+- later checkpoints follow the same event/state pattern
+
+## Non-negotiable Forge rules
+- Never use production as a preview surface when a preview pipeline exists.
+- Never call a merge 'live'. Verify deployment.
+- Never require buyers to clear cache as the normal upgrade mechanism.
+- Never fork shared application code for a new buyer.
+- Never overwrite buyer state merely to deploy UI.
+- Never expose internal HBE notes in buyer-visible payloads.
+- Prefer simple, reversible changes while the system is still being learned.
+- Preserve the buyer-first design principle: technology should improve understanding and decision quality, not pressure movement through stages.
+
+## Immediate next action
+Implement Phase 0 only. Report the actual hosting/deployment facts and proposed preview implementation before changing production infrastructure.

--- a/docs/buyer-platform/FORGE_START_HERE.md
+++ b/docs/buyer-platform/FORGE_START_HERE.md
@@ -1,0 +1,47 @@
+# Forge Start Here — HBE Buyer Platform
+
+## Mission
+Build HBE's BuyerUI and HBEUI as one living buyer-engagement platform that can improve continuously without stranding active buyers on old revisions.
+
+## Governing principle
+Buyer data and buyer progress must persist independently of UI releases. The experience can evolve around the human without resetting the human.
+
+## Required operating loop
+1. Build on an `agent/*` branch.
+2. Produce an interactive preview URL from that exact branch/commit.
+3. Do not call anything "live" until the deployed URL is verified against the expected release/commit.
+4. Human approval happens in preview.
+5. Merge only after approval.
+6. Production release automatically increments one release ID.
+7. Shared BuyerUI assets use that release ID for cache invalidation.
+8. Active BuyerUI sessions detect the new release and upgrade without manual cache clearing.
+9. Rollback must be possible without changing buyer records.
+
+## Platform boundaries
+- **Buyer profile data:** identity, answers, preferences, WHY, progress, decisions, photos/notes, messages and stage state.
+- **Shared BuyerUI:** roadmap rendering, checkpoint behavior, status bubbles, communication affordances, release logic, visual system.
+- **Shared HBEUI:** human engagement dashboard, advisor roadmap, task/capture screens, navigation, buyer-facing status output.
+- **Deployment layer:** preview, production, release manifest, verification and rollback.
+
+Never solve a shared-platform problem by hard-coding another buyer-specific page unless the data itself is buyer-specific.
+
+## Immediate implementation order
+1. Establish dependable preview deployment.
+2. Establish release-driven shared asset loading.
+3. Refactor buyer pages toward one shared BuyerUI shell plus buyer configuration/data.
+4. Add automated deployment verification.
+5. Add rollback procedure.
+6. Only then resume expansion of HBEUI and later buyer-process stages.
+
+## Definition of done for a Forge change
+A change is not done when code is committed or merged. It is done when:
+- preview URL loads;
+- intended buyer can authenticate;
+- expected release/commit is visible or machine-verifiable;
+- shared assets load without 404s;
+- roadmap and interaction checks pass;
+- approver has seen the preview;
+- production deployment is verified after merge;
+- active buyers can receive the release automatically.
+
+Read the other files in this folder before implementation.

--- a/docs/buyer-platform/HOSTING.md
+++ b/docs/buyer-platform/HOSTING.md
@@ -1,0 +1,133 @@
+# HBE Buyer Platform — Hosting Contract (Phase 0)
+
+This document records observed repository/deployment facts. Unknowns are labeled as unknown instead of guessed.
+
+## Confirmed repository facts
+
+- Repository: `Gadjetfreek/hbexperts-site`
+- Visibility: public
+- Default branch: `main`
+- Static-site generator: Hugo
+- Hugo version used for deployment: `0.147.8` extended
+- Hugo configuration file: `hugo.toml`
+- Hugo theme: `hbe`
+
+## Confirmed production deployment mechanism
+
+Production is deployed by GitHub Actions, not by publishing a branch directly.
+
+Workflow file: `.github/workflows/deploy.yml`
+Workflow name: `Deploy Hugo to GitHub Pages`
+
+Trigger:
+- push to `main`
+- manual `workflow_dispatch`
+
+The workflow does NOT trigger on pull requests or `agent/*` branch pushes.
+
+Deployment sequence:
+1. checkout repository
+2. install Hugo Extended 0.147.8
+3. call `actions/configure-pages@v5`
+4. run Hugo with `--gc --minify`
+5. override Hugo base URL with `${{ steps.pages.outputs.base_url }}/`
+6. upload `./public` with `actions/upload-pages-artifact@v3`
+7. deploy that artifact with `actions/deploy-pages@v4`
+8. publish into the `github-pages` environment
+
+Therefore a commit existing on `main` does not itself prove that it is live. The GitHub Pages deployment must complete successfully.
+
+## Confirmed publish-path behavior
+
+Hugo generates the deployable site into `./public` during the Actions run. `public/` is build output and is not tracked in the repository.
+
+Files under repository `static/` are Hugo static assets. Hugo copies them into the root of generated `public/`.
+
+Example:
+- source: `static/buyers/donald-kelley/index.html`
+- deployed path: `/buyers/donald-kelley/`
+
+This explains why a file created under `static/` can appear at a URL without `/static/` after a successful Hugo deployment.
+
+## Confirmed URL/baseURL behavior
+
+`hugo.toml` contains:
+
+`baseURL = "https://hbexperts.com/"`
+
+However the production Actions workflow explicitly overrides that value during deployment with the Pages-provided base URL:
+
+`--baseURL "${{ steps.pages.outputs.base_url }}/"`
+
+Therefore repository `hugo.toml` alone does not determine the deployed production URL. GitHub Pages configuration determines the runtime base URL used by the production build.
+
+## Confirmed preview facts
+
+There is currently no repository-native PR preview pipeline.
+
+The production workflow only builds/deploys `main`. A page added only to an unmerged `agent/*` branch cannot appear on the production GitHub Pages site.
+
+There is no `gh-pages` branch in the repository.
+
+The failed Donald preview attempt was therefore structurally expected: the preview code existed on an unmerged branch, while the only deployed artifact came from `main`.
+
+A later `preview.html` harness was committed to `main`, but that still depends on the normal production deployment completing before its URL can exist. It is not a true branch preview system.
+
+## CI/CD and external host findings
+
+Confirmed:
+- `.github/workflows/deploy.yml` is an active deployment definition in the repository.
+- no `netlify.toml` exists at repository root.
+- no tracked `public/` output exists.
+
+Not yet proven from available repository evidence:
+- whether any external service (Netlify, Vercel, Cloudflare Pages, etc.) is connected out-of-band through provider dashboards
+- whether GitHub Pages has a custom domain configured in repository Settings
+- current DNS records for `hbexperts.com`
+
+No root `CNAME` file or `static/CNAME` file was found in the repository. That means a custom domain, if configured, is not currently represented by a tracked CNAME file in this repo.
+
+## Why recent preview/release attempts behaved inconsistently
+
+1. We treated branch code as though GitHub Pages could serve it. It cannot with the current workflow.
+2. We treated merge completion as deploy completion. The workflow is asynchronous after the merge/push.
+3. Our first live-release watcher updated the page URL but shared CSS/JS still contained hard-coded old version query strings.
+4. A release manifest change only helps a browser after both the manifest and release-driven asset-loading code have themselves been successfully deployed.
+
+These were pipeline-contract problems, not only BuyerUI visual-code problems.
+
+## Proposed Phase 1 direction (proposal only — not implemented in Phase 0)
+
+The simplest architecture consistent with the current repository is to add a second GitHub Actions workflow dedicated to previews.
+
+Recommended characteristics:
+- trigger on pull requests affecting BuyerUI/HBEUI/site files
+- build Hugo from the exact PR commit
+- stamp the build with commit SHA and PR number
+- deploy preview independently from production
+- return a stable discoverable preview URL to the PR
+- run HTTP/smoke verification before calling preview ready
+- never mutate the `github-pages` production environment
+
+A provider or deployment strategy must be selected before implementation. GitHub Pages itself is designed around one Pages site/environment per repository and is not a convenient native per-PR hosting surface. A separate preview host/service or an isolated preview publishing strategy is therefore preferable.
+
+## Phase 1 acceptance test to implement next
+
+For Donald's pending BuyerUI status-bubble revision:
+1. push/update the preview branch
+2. preview workflow builds that exact SHA
+3. preview deployment succeeds
+4. preview page displays its commit SHA visibly or in machine-readable metadata
+5. Donald exercise credentials work
+6. proposed Headquarters status bubble and `YOUR WHY` destination are visible
+7. production Donald BuyerUI remains unchanged
+8. Chris approves the interactive preview
+9. only then merge/release to production
+
+## Phase 0 conclusion
+
+The current production contract is now understood well enough to stop guessing:
+
+`push to main -> deploy.yml -> Hugo build -> ./public artifact -> GitHub Pages environment -> production URL`
+
+The missing capability is not another cache workaround. It is a real branch/PR preview deployment path plus explicit deployment verification.


### PR DESCRIPTION
## Archived / superseded

This August 2026 operating-structure PR served its purpose during discovery. The live buyer platform now exists in `secure-platform`, with later issues and merged PRs governing the current architecture, deployment, buyer-first UX, security boundaries, and operating workflow.

Preserve this PR as historical context only. Do not treat it as the current platform plan.

## Original scope

- buyer-first platform charter and ownership boundaries
- shared BuyerUI vs buyer data vs HBEUI architecture
- preview / approve / publish / verify / rollback delivery contract
- active-buyer upgrade expectations
- sequenced implementation plan