### PR TITLE
Phase 1: add isolated PR preview pipeline

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,151 @@
+name: Build Buyer Platform Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# All preview builds publish into one branch, so serialize writes.
+concurrency:
+  group: hbe-preview-publish
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  preview:
+    # Do not give write-capable preview jobs to forked PRs.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.147.8
+
+    steps:
+      - name: Checkout exact PR commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Install Hugo CLI
+        run: |
+          wget -q -O "${{ runner.temp }}/hugo.deb" \
+            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          sudo dpkg -i "${{ runner.temp }}/hugo.deb"
+
+      - name: Define immutable preview identity
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          SOURCE_SHA="${{ github.event.pull_request.head.sha }}"
+          SHORT_SHA="${SOURCE_SHA:0:12}"
+          PREVIEW_PATH="pr-${PR_NUMBER}/${SHORT_SHA}"
+          PREVIEW_ROOT="https://raw.githack.com/${GITHUB_REPOSITORY}/previews/${PREVIEW_PATH}/"
+          echo "PR_NUMBER=${PR_NUMBER}" >> "$GITHUB_ENV"
+          echo "SOURCE_SHA=${SOURCE_SHA}" >> "$GITHUB_ENV"
+          echo "SHORT_SHA=${SHORT_SHA}" >> "$GITHUB_ENV"
+          echo "PREVIEW_PATH=${PREVIEW_PATH}" >> "$GITHUB_ENV"
+          echo "PREVIEW_ROOT=${PREVIEW_ROOT}" >> "$GITHUB_ENV"
+
+      - name: Build Hugo preview
+        env:
+          HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
+          TZ: America/New_York
+        run: |
+          hugo --gc --minify --baseURL "${PREVIEW_ROOT}"
+
+      - name: Make shared BuyerUI assets preview-safe and stamp build
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import json, os
+
+          root = os.environ["PREVIEW_ROOT"]
+          sha = os.environ["SOURCE_SHA"]
+          pr = os.environ["PR_NUMBER"]
+
+          for path in Path("public").rglob("*"):
+              if not path.is_file() or path.suffix.lower() not in {".html", ".js", ".css"}:
+                  continue
+              text = path.read_text(encoding="utf-8")
+              # BuyerUI currently contains a few root-absolute shared-asset references.
+              # Rewrite only the known shared namespace rather than all root links.
+              text = text.replace('"/buyer-portal/', f'"{root}buyer-portal/')
+              text = text.replace("'/buyer-portal/", f"'{root}buyer-portal/")
+              if path.suffix.lower() == ".html" and "</head>" in text:
+                  stamp = f'<meta name="hbe-preview" content="pr-{pr}@{sha}">'
+                  text = text.replace("</head>", stamp + "</head>", 1)
+              path.write_text(text, encoding="utf-8")
+
+          Path("public/__hbe-preview.json").write_text(
+              json.dumps({
+                  "preview": True,
+                  "pull_request": int(pr),
+                  "source_sha": sha,
+                  "source_branch": os.environ.get("GITHUB_HEAD_REF", ""),
+              }, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Validate build before publish
+        run: |
+          test -f public/index.html
+          test -f public/buyers/donald-kelley/index.html
+          test -f public/buyer-portal/dashboard.js
+          test -f public/__hbe-preview.json
+          grep -q "${SOURCE_SHA}" public/__hbe-preview.json
+
+      - name: Checkout preview storage branch
+        uses: actions/checkout@v4
+        with:
+          ref: previews
+          path: preview-store
+          fetch-depth: 0
+
+      - name: Publish immutable preview bundle
+        working-directory: preview-store
+        run: |
+          mkdir -p "${PREVIEW_PATH}"
+          rm -rf "${PREVIEW_PATH:?}"/*
+          cp -a ../public/. "${PREVIEW_PATH}/"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "${PREVIEW_PATH}"
+          if git diff --cached --quiet; then
+            echo "Preview bundle already published."
+          else
+            git commit -m "Preview PR ${PR_NUMBER} at ${SHORT_SHA}"
+            git pull --rebase origin previews
+            git push origin HEAD:previews
+          fi
+
+      - name: Verify browser preview endpoint
+        run: |
+          URL="${PREVIEW_ROOT}buyers/donald-kelley/index.html"
+          echo "Checking ${URL}"
+          curl --fail --silent --show-error --location \
+            --retry 8 --retry-delay 5 --retry-all-errors \
+            "${URL}" > "${{ runner.temp }}/preview.html"
+          grep -q "hbe-preview" "${{ runner.temp }}/preview.html"
+
+      - name: Publish preview link to PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          URL="${PREVIEW_ROOT}buyers/donald-kelley/index.html"
+          gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --body "$(cat <<EOF
+          ### HBE interactive preview ready
+
+          **Exact source commit:** \`${SOURCE_SHA}\`
+
+          [Open Donald BuyerUI preview](${URL})
+
+          This preview is built from this PR commit and stored outside the production GitHub Pages deployment. It does not change the live BuyerUI. raw.githack may show a one-time safety confirmation before displaying repository HTML.
+          EOF
+          )"


### PR DESCRIPTION
## Forge Phase 1

Adds the first real branch/PR preview pipeline for HBE BuyerUI/HBEUI work.

### Contract
- production GitHub Pages remains untouched
- preview builds the exact PR head SHA with Hugo 0.147.8
- each build is stored immutably at `previews/pr-<number>/<short-sha>/`
- build is stamped with PR + full commit SHA
- required Donald/shared BuyerUI files are verified before publish
- browser endpoint is checked after publish
- successful workflow comments the interactive Donald preview URL on the PR
- forked PRs cannot run the write-capable publisher

### Why this approach first
It requires no additional hosting account or secret. The `previews` branch is only preview storage; production remains the existing Actions -> GitHub Pages environment.

### Acceptance
This PR is intentionally the first test of the workflow itself. Once the workflow exists on `main`, subsequent BuyerUI PRs will automatically produce their own preview URLs. The Donald Headquarters status-bubble revision will be the first visual acceptance test.