### PR TITLE
Phase 4: verify production deployments automatically

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,10 +44,7 @@ jobs:
           HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
           TZ: America/New_York
         run: |
-          hugo \
-            --gc \
-            --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
+          hugo --gc --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
 
       - name: Stamp production release and make BuyerUI assets release-driven
         env:
@@ -56,29 +53,18 @@ jobs:
           python3 - <<'PY'
           from pathlib import Path
           import json, os, re
-
-          release = os.environ['RELEASE_ID']
-          short = release[:12]
-          portal = Path('public/buyer-portal')
-          portal.mkdir(parents=True, exist_ok=True)
-          (portal / 'release.json').write_text(json.dumps({
-              'release': release,
-              'shortRelease': short,
-              'checkIntervalMs': 30000
-          }, separators=(',', ':')) + '\n', encoding='utf-8')
-
-          # Every production HTML page that uses BuyerUI shared assets gets the
-          # exact deployment SHA as its cache key. No manual version bump.
+          release=os.environ['RELEASE_ID']; short=release[:12]
+          portal=Path('public/buyer-portal'); portal.mkdir(parents=True,exist_ok=True)
+          (portal/'release.json').write_text(json.dumps({'release':release,'shortRelease':short,'checkIntervalMs':30000},separators=(',',':'))+'\n',encoding='utf-8')
           for path in Path('public').rglob('*.html'):
-              text = path.read_text(encoding='utf-8')
-              text = re.sub(r'(/buyer-portal/[^"\'?#]+\.(?:css|js))(?:[?][^"\']*)?',
-                            lambda m: m.group(1) + '?release=' + release, text)
+              text=path.read_text(encoding='utf-8')
+              text=re.sub(r'(/buyer-portal/[^"\'?#]+\.(?:css|js))(?:[?][^"\']*)?',lambda m:m.group(1)+'?release='+release,text)
               if '</head>' in text and 'hbe-production-release' not in text:
-                  text = text.replace('</head>', f'<meta name="hbe-production-release" content="{release}"></head>', 1)
-              path.write_text(text, encoding='utf-8')
+                  text=text.replace('</head>',f'<meta name="hbe-production-release" content="{release}"></head>',1)
+              path.write_text(text,encoding='utf-8')
           PY
 
-      - name: Verify release contract
+      - name: Verify release contract before upload
         env:
           RELEASE_ID: ${{ github.sha }}
         run: |
@@ -86,6 +72,7 @@ jobs:
           grep -q "${RELEASE_ID}" public/buyer-portal/release.json
           test -f public/buyers/donald-kelley/index.html
           grep -q "hbe-production-release" public/buyers/donald-kelley/index.html
+          test -f public/buyer-portal/buyer-app.js
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
@@ -98,7 +85,47 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  verify-production:
+    name: Verify deployed production release
+    runs-on: ubuntu-latest
+    needs: deploy
+    env:
+      RELEASE_ID: ${{ github.sha }}
+      PAGE_URL: ${{ needs.deploy.outputs.page_url }}
+    steps:
+      - name: Wait for exact release manifest
+        run: |
+          BASE="${PAGE_URL%/}"
+          URL="${BASE}/buyer-portal/release.json?verify=${RELEASE_ID}"
+          echo "Verifying ${URL}"
+          for attempt in {1..18}; do
+            BODY="$(curl --fail --silent --show-error --location --max-time 15 "${URL}" || true)"
+            if printf '%s' "$BODY" | grep -q "${RELEASE_ID}"; then
+              echo "Exact release ${RELEASE_ID} is live."
+              exit 0
+            fi
+            echo "Attempt ${attempt}: deployed endpoint has not reached expected release yet."
+            sleep 10
+          done
+          echo "Production never served expected release ${RELEASE_ID}." >&2
+          exit 1
+
+      - name: Smoke test shared BuyerUI production assets
+        run: |
+          BASE="${PAGE_URL%/}"
+          curl --fail --silent --show-error --location "${BASE}/buyers/donald-kelley/?verify=${RELEASE_ID}" > /tmp/donald.html
+          grep -q "${RELEASE_ID}" /tmp/donald.html
+          curl --fail --silent --show-error --location "${BASE}/buyer-portal/buyer-app.js?release=${RELEASE_ID}" > /tmp/buyer-app.js
+          test -s /tmp/buyer-app.js
+
+      - name: Record verified release
+        run: |
+          echo "VERIFIED_PRODUCTION_RELEASE=${RELEASE_ID}" >> "$GITHUB_STEP_SUMMARY"
+          echo "PRODUCTION_URL=${PAGE_URL}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Forge Phase 4 — deployment verification

Adds the missing distinction between **merged**, **deployed**, and **verified live**.

### Changes
- production deploy job now exposes its actual GitHub Pages URL
- a post-deploy verification job polls the deployed `release.json` until the exact merge SHA is served
- verification fails if production never reaches the expected release
- smoke-tests Donald's BuyerUI entrypoint and the new shared `buyer-app.js`
- records the verified production release and URL in the Actions job summary

### Safety
No buyer data changes. No rollback is automated in this slice: a failed verification stops us from declaring a release healthy rather than attempting an unsafe blind rollback.

### Release semantics after this PR
`merged` != `live`

A release is healthy only after `verify-production` confirms the exact release SHA from the deployed endpoint.

### Preview
Phase 1 should build this workflow change in isolation before merge.