### PR TITLE
Add source-linked Reviews & Recommendations page

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -138,6 +138,16 @@ When you work with HomeBuyer Experts, you should expect:
 
 ---
 
+## What Others Have Said
+
+Independent reviews and professional recommendations can add useful context, but we prefer that you see them at their original source rather than only through our retelling.
+
+We have collected links to recommendations and reviews for HomeBuyer Experts and Christopher Whitehead on LinkedIn, Angi, Zillow, and Google.
+
+[Read Reviews & Recommendations →]({{< relref "reviews" >}})
+
+---
+
 ## Explore before you decide
 
 You can see the whole HBE Buyer Journey before sharing anything with us.

--- a/content/reviews.md
+++ b/content/reviews.md
@@ -10,27 +10,27 @@ We would rather point you to the original source than turn someone else's words 
 
 ### LinkedIn
 
-Christopher Whitehead's LinkedIn profile currently shows **13 recommendations received** from colleagues and professional contacts.
+Christopher Whitehead's LinkedIn profile currently shows **13 recommendations received**.
 
-[Read Christopher's recommendations on LinkedIn →](https://www.linkedin.com/in/christopher-whitehead-37781759/details/recommendations/)
+[Read Christopher's recommendations on LinkedIn →](https://www.linkedin.com/in/buyerbroker/)
 
 ### Angi
 
 HomeBuyer Experts currently shows **8 reviews with a 5.0 overall rating** on Angi.
 
-[Read the HomeBuyer Experts reviews on Angi →](https://www.angi.com/companylist/us/oh/akron/homebuyer-experts-reviews-2288437.htm)
+[Read the HomeBuyer Experts reviews on Angi →](https://www.angi.com/companylist/us/oh/akron/homebuyer-experts-reviews-6373979.htm)
 
 ### Zillow
 
-The HomeBuyer Experts / Christopher Whitehead team profile currently shows **3 reviews with a 5.0 rating** on Zillow.
+The Christopher Whitehead / HomeBuyer Experts team profile currently shows **3 team reviews with a 5.0 rating** on Zillow.
 
-[Read the reviews on Zillow →](https://www.zillow.com/profile/HomeBuyerExperts/)
+[Read the reviews on Zillow →](https://www.zillow.com/profile/Buyer_Broker)
 
 ### Google
 
 HomeBuyer Experts' Google business listing currently shows a **5.0 rating from 1 review**.
 
-[View HomeBuyer Experts on Google →](https://www.google.com/search?q=HomeBuyer+Experts+Akron+Ohio)
+[View HomeBuyer Experts on Google →](https://www.google.com/maps/search/?api=1&query=HomeBuyer+Experts+Akron+Ohio&query_place_id=ChIJ0QWMhJ7QMIgRRrdxxRjjS7s)
 
 ---
 

--- a/content/reviews.md
+++ b/content/reviews.md
@@ -1,0 +1,47 @@
+---
+title: "Reviews & Recommendations"
+subtitle: "A few places where past clients and colleagues have shared their experience with HomeBuyer Experts and Christopher Whitehead."
+description: "Independent reviews and recommendations for HomeBuyer Experts and Christopher Whitehead, with links back to the original platforms."
+---
+
+## Read the originals
+
+We would rather point you to the original source than turn someone else's words into marketing copy. The links below take you back to the platform where each recommendation or review was originally published.
+
+### LinkedIn
+
+Christopher Whitehead's LinkedIn profile currently shows **13 recommendations received** from colleagues and professional contacts.
+
+[Read Christopher's recommendations on LinkedIn →](https://www.linkedin.com/in/christopher-whitehead-37781759/details/recommendations/)
+
+### Angi
+
+HomeBuyer Experts currently shows **8 reviews with a 5.0 overall rating** on Angi.
+
+[Read the HomeBuyer Experts reviews on Angi →](https://www.angi.com/companylist/us/oh/akron/homebuyer-experts-reviews-2288437.htm)
+
+### Zillow
+
+The HomeBuyer Experts / Christopher Whitehead team profile currently shows **3 reviews with a 5.0 rating** on Zillow.
+
+[Read the reviews on Zillow →](https://www.zillow.com/profile/HomeBuyerExperts/)
+
+### Google
+
+HomeBuyer Experts' Google business listing currently shows a **5.0 rating from 1 review**.
+
+[View HomeBuyer Experts on Google →](https://www.google.com/search?q=HomeBuyer+Experts+Akron+Ohio)
+
+---
+
+## A note about reviews
+
+Reviews are one person's experience, not a guarantee of what another buyer will experience. We include them because independent third-party feedback can provide useful context about how HBE has worked with people in the past.
+
+For us, the more important test remains the same:
+
+> **What is best for the buyer?**
+
+If you are considering HBE, we encourage you to explore the Buyer Journey first and decide whether our approach fits the way you want to make this decision.
+
+[Explore the Buyer Journey →](https://buyer.hbexperts.com/)

--- a/content/reviews.md
+++ b/content/reviews.md
@@ -1,42 +1,76 @@
 ---
 title: "Reviews & Recommendations"
-subtitle: "A few places where past clients and colleagues have shared their experience with HomeBuyer Experts and Christopher Whitehead."
-description: "Independent reviews and recommendations for HomeBuyer Experts and Christopher Whitehead, with links back to the original platforms."
+subtitle: "What past clients and colleagues have said about HomeBuyer Experts and Christopher Whitehead — with the original platform identified whenever we can verify it."
+description: "Independent reviews and recommendations for HomeBuyer Experts and Christopher Whitehead, with source context and links back to the original platforms when available."
 ---
 
-## Read the originals
+## Read the originals — and the context
 
-We would rather point you to the original source than turn someone else's words into marketing copy. The links below take you back to the platform where each recommendation or review was originally published.
+We would rather show you what people actually said than turn their words into polished marketing copy. We use only brief excerpts here, identify the original platform, and link back whenever the source provides a stable public page.
+
+**Source information checked August 31, 2026.** Review counts and ratings can change over time.
 
 ### LinkedIn
 
-Christopher Whitehead's LinkedIn profile currently shows **13 recommendations received**.
+Christopher Whitehead's LinkedIn profile shows **13 recommendations received**.
+
+> **Julie:** “Working with Chris as our Home Buyer Expert was one of the best decisions that my husband and I have made.”
+
+> **Marge:** “Chris is a very positive member of our group.”
 
 [Read Christopher's recommendations on LinkedIn →](https://www.linkedin.com/in/buyerbroker/)
 
 ### Angi
 
-HomeBuyer Experts currently shows **8 reviews with a 5.0 overall rating** on Angi.
+HomeBuyer Experts shows **8 reviews with a 5.0 overall rating** on Angi. These reviews are historical, primarily from 2011–2015.
+
+> **Frank:** “They were very personable.”
+
+> **Barb:** “Chris is your partner in finding the right home.”
+
+> **Matthew:** “He puts your needs first.”
 
 [Read the HomeBuyer Experts reviews on Angi →](https://www.angi.com/companylist/us/oh/akron/homebuyer-experts-reviews-6373979.htm)
 
 ### Zillow
 
-The Christopher Whitehead / HomeBuyer Experts team profile currently shows **3 team reviews with a 5.0 rating** on Zillow.
+The Christopher Whitehead / HomeBuyer Experts team profile shows **3 team reviews with a 5.0 rating**. The three visible reviews date from 2014.
+
+> **A Zillow reviewer:** “Chris was the consumate professional with the right skill set to best assist a home buyer.”
+
+> **A Zillow reviewer:** “I couldn't have asked for a better experience buying my first home.”
+
+> **A Zillow reviewer:** “Chris was great. He listens very well.”
 
 [Read the reviews on Zillow →](https://www.zillow.com/profile/Buyer_Broker)
 
+A public Experience.com profile also mirrors the three Zillow reviews if Zillow's review text is difficult to display directly.
+
+[View the mirrored review record →](https://www.experience.com/reviews/christopher-14881419)
+
 ### Google
 
-HomeBuyer Experts' Google business listing currently shows a **5.0 rating from 1 review**.
+HomeBuyer Experts' Google business listing showed a **5.0 rating from 1 review** when checked on August 31, 2026.
+
+We have not reproduced that review's wording here because we could not reliably retrieve the review text from a stable public page. We would rather cite the existence of the review than guess at or paraphrase words we cannot verify.
 
 [View HomeBuyer Experts on Google →](https://www.google.com/maps/search/?api=1&query=HomeBuyer+Experts+Akron+Ohio&query_place_id=ChIJ0QWMhJ7QMIgRRrdxxRjjS7s)
 
 ---
 
+## Historical reviews and today's relationship
+
+Older reviews describe the service, business practices, and buyer-agent relationship as they existed when those reviews were written. Some historical reviews discuss compensation arrangements or other practices that may not describe today's agreement.
+
+Current representation, responsibilities, and compensation are governed by the agreement you review with HomeBuyer Experts today. Compensation is negotiable and should be understood before you decide whether to hire HBE.
+
+We deliberately avoid excerpting old fee-model language here because historical compensation terms should not be mistaken for a current offer or promise.
+
+---
+
 ## A note about reviews
 
-Reviews are one person's experience, not a guarantee of what another buyer will experience. We include them because independent third-party feedback can provide useful context about how HBE has worked with people in the past.
+Reviews are individual experiences, not a guarantee of what another buyer will experience. We include them because independent third-party feedback can provide useful context about how HBE has worked with people in the past.
 
 For us, the more important test remains the same:
 


### PR DESCRIPTION
## Objective
Add independent, source-linked reviews/recommendations without putting testimonials on the homepage.

## Changes
- Adds `/reviews/` with links back to LinkedIn, Angi, Zillow, and Google.
- Adds a restrained `What Others Have Said` section to About that links to `/reviews/`.
- No homepage changes.
- No production deployment in this PR.

## Governance
This is public-facing website content, so treat as owner-approved public-content work requiring Sentinel review before merge. Sebastian explicitly requested these recommendations be posted and clarified they should not appear on the homepage.

## Source posture
The page points visitors to original third-party platforms rather than reproducing long testimonials. Platform counts/ratings should be re-verified immediately before merge because they can change.
