### PR TITLE
Mobile UX pass: stronger stage contrast and clearer next-step guidance

### DIFF
--- a/secure-platform/src/issue29-production-worker.js
+++ b/secure-platform/src/issue29-production-worker.js
@@ -1,9 +1,64 @@
 import appWorker from './issue29-convergence-worker.js';
 
-// Final production wrapper for Issue #29.
-// Keep this layer intentionally small: the convergence worker owns behavior;
-// this wrapper only removes the stale pre-invite wording that said email delivery
-// was blocked after the buyer-mail-app invitation flow was implemented.
+// Production presentation wrapper for Issue #29.
+// The convergence worker owns product behavior and persistence. This wrapper is
+// intentionally limited to final copy/presentation refinements that do not
+// change authorization, data boundaries, or journey state.
+const MOBILE_UX_CSS = `<style id="hbe-mobile-ux-pass">
+/* Keep future stages quieter without making their popovers translucent. */
+.i29-stop.future{opacity:1!important}
+.i29-stop.future>.i29-num,.i29-stop.future>div:not(.i29-peek){opacity:.62}
+
+/* Popovers need to read like solid information cards, especially on phones. */
+.i29-peek{
+  background:#fff!important;
+  color:#1a1a2e!important;
+  border:2px solid rgba(26,26,46,.24)!important;
+  box-shadow:0 18px 50px rgba(26,26,46,.28)!important;
+}
+.i29-peek li{color:#2c2c2c}
+
+/* A single directional cue: do What's Next first; details stay optional. */
+.i29-guide{
+  display:flex;
+  gap:.65rem;
+  align-items:flex-start;
+  margin:.9rem 0 1rem;
+  padding:.8rem .9rem;
+  border:1px solid #d8d4ca;
+  border-left:4px solid #2d5a3d;
+  border-radius:10px;
+  background:#faf9f6;
+  color:#2c2c2c;
+  line-height:1.4;
+}
+.i29-guide strong{flex:0 0 auto;color:#1a1a2e}
+.i29-guide span{font-size:.92rem}
+
+@media(max-width:560px){
+  .i29-stop{min-height:auto}
+  .i29-peek{
+    position:relative!important;
+    left:auto!important;
+    bottom:auto!important;
+    grid-column:1/-1;
+    width:100%!important;
+    margin-top:.7rem;
+    transform:none!important;
+    box-shadow:0 10px 28px rgba(26,26,46,.24)!important;
+    display:none;
+    opacity:1!important;
+    visibility:visible!important;
+  }
+  .i29-stop.open .i29-peek,
+  .i29-stop:focus-within .i29-peek{display:block}
+  .i29-guide{display:block;padding:.75rem .8rem}
+  .i29-guide strong{display:block;margin-bottom:.15rem}
+}
+</style>`;
+
+const START_HERE = `<div class="i29-guide" role="note"><strong>Start here.</strong><span>Do the What’s Next item first. Open your current stage when you want the details. Everything else is context, not homework.</span></div>`;
+
 export default {
   async fetch(request, env, ctx) {
     const response = await appWorker.fetch(request, env, ctx);
@@ -13,10 +68,29 @@ export default {
     if (!type.includes('text/html')) return response;
 
     let text = await response.text();
+
+    // Remove stale invitation wording after the buyer-mail-app flow shipped.
     text = text.replace(
       'Email delivery of this invitation is an architecture blocker until a verified sending domain and the HBE_ALERT Send Email binding are enabled. Until then, share the copyable link. Do not enter the other buyer’s email here.',
-      'Create the private invitation first. Then you can open your own mail app with the secure invitation link already included, or copy the link and share it another way. HBE does not collect the other buyer’s email at this step.'
+      'Create the private invitation, then email the secure link from your own mail app or copy it to share another way. HBE does not collect the other buyer’s email here.'
     );
+
+    // Reduce repeated explanatory language while preserving the deeper detail.
+    text = text
+      .replace('Highest priority right now', 'Do this next')
+      .replace('Empty-state fallback is still a useful HBE action', 'Best next HBE action')
+      .replace('Empty-state fallback is still a useful buyer action', 'Best next step')
+      .replace('From a checklist item that created this action', 'From your current checklist')
+      .replace('Highest-priority open task', 'Highest priority');
+
+    // Put one clear directional cue immediately before the primary action area.
+    if (text.includes('<section class="i29-next" id="whats-next">') && !text.includes('class="i29-guide"')) {
+      text = text.replace('<section class="i29-next" id="whats-next">', `${START_HERE}<section class="i29-next" id="whats-next">`);
+    }
+
+    if (!text.includes('id="hbe-mobile-ux-pass"')) {
+      text = text.replace('</head>', `${MOBILE_UX_CSS}</head>`);
+    }
 
     return new Response(text, {
       status: response.status,


### PR DESCRIPTION
## Why
First live-phone usability pass after Issue #29 production launch.

## User feedback addressed
- Stage popovers on phone are too transparent / low contrast.
- The portal contains useful information but the flow does not feel intuitive enough.
- Direction should be felt without turning the journey into a mandatory wizard.
- Reduce repeated explanatory wording where possible.

## Changes
- Future stages no longer reduce opacity on the entire card, which had also dimmed their popovers.
- Popovers use a solid white surface, stronger border, and stronger shadow.
- On narrow phones, an opened stage explanation expands inline as a solid card instead of floating faintly over other content.
- Adds one compact `Start here` cue before What’s Next: do the primary next item first; current stage/checklists are optional detail.
- Tightens several repeated What’s Next reason labels.
- Shortens the co-buyer invitation helper copy.

## Safety
Presentation/copy wrapper only. No auth, D1 schema, household state, privacy boundaries, stage definitions, or task logic changed.

## Deployment
Requires the same guarded Worker deployment path after Sentinel review. Public Hugo site is unaffected.