### PR TITLE
Issue #33: BIMatrix BuyerUI, freshness checks, and deterministic seed programs

### DIFF
--- a/secure-platform/bimatrix/catalog/akron-dreams.json
+++ b/secure-platform/bimatrix/catalog/akron-dreams.json
@@ -1,0 +1,245 @@
+{
+  "program_id": "akron-dreams",
+  "version": 1,
+  "name": "Akron Dreams 2026",
+  "administrator": "East Akron Neighborhood Development Corporation (EANDC), in partnership with the City of Akron",
+  "summary_plain_english": "Akron Dreams is a City of Akron first-time homebuyer program that can provide a forgivable $7,500 loan toward down payment and closing costs for an eligible owner-occupant purchasing inside Akron city limits.",
+  "status": "open",
+  "benefit": {
+    "type": "forgivable_assistance",
+    "summary": "Forgivable down-payment/closing-cost assistance of $7,500, subject to program funding and final administrator approval.",
+    "amount_min": 7500,
+    "amount_max": 7500,
+    "amount_formula": null
+  },
+  "geography": {
+    "state": "OH",
+    "municipality": "Akron",
+    "property_must_be_inside_city_limits": true
+  },
+  "criteria": {
+    "funding_source": "HUD HOME Program",
+    "first_time_definition": "Buyer must not have been a property owner in the prior three years.",
+    "owner_occupied_required": true,
+    "mortgage_preapproval_required": true,
+    "mortgage_term_required": "30-year fixed-rate",
+    "homebuyer_education_required": "Minimum 8 hours with a HUD-approved counseling agency; EANDC program page states certification within the last two years.",
+    "minimum_credit_score": 620,
+    "bankruptcy_foreclosure_lookback_years": 2,
+    "minimum_buyer_contribution_percent_purchase_price": 1,
+    "liquid_asset_cap_dollars": 15000,
+    "property_units_allowed": [1, 2],
+    "underwriting_ratios": {"housing_percent": 35, "total_debt_percent": 45},
+    "income_limits_by_household_size": {
+      "1": 54400,
+      "2": 62200,
+      "3": 69950,
+      "4": 77701,
+      "5": 83950,
+      "6": 90150,
+      "7": 96350,
+      "8": 102600
+    },
+    "income_limit_basis": "80% HUD Area Median Income as published for Akron Dreams 2026",
+    "property_value_rule": "Property value cannot exceed 95% of Akron's median purchase price for single-family housing; the current dollar threshold requires administrator/source confirmation before deterministic evaluation."
+  },
+  "terms": {
+    "deed_restriction_years": 5,
+    "secured_by_second_mortgage_lien": true,
+    "cash_back_to_borrower_at_closing": false,
+    "funding_priority": "First-come, first-served"
+  },
+  "tradeoffs": [
+    "The property is deed-restricted for five years and the assistance is secured by a second-mortgage lien.",
+    "The buyer must contribute at least 1% of the purchase price.",
+    "Liquid assets above $15,000 must first be applied to the purchase under the published criteria.",
+    "Funding is first-come, first-served, so matching the eligibility rules does not guarantee money will still be available.",
+    "The buyer should compare this assistance with alternative financing based on cash required, monthly payment, rate, lien/forgiveness terms, and total borrowing cost."
+  ],
+  "rules": [
+    {
+      "rule_id": "akron-city-limits",
+      "fact_keys": ["target.municipality"],
+      "operator": "equals",
+      "comparison": "Akron",
+      "failure_effect": "not_match",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["eandc-akron-dreams"],
+      "buyer_reason_fail": "The published program requires the property to be inside the City of Akron.",
+      "buyer_reason_missing": "We need the target municipality or property address to confirm Akron city limits."
+    },
+    {
+      "rule_id": "first-time-three-years",
+      "fact_keys": ["household.property_owner_within_3_years"],
+      "operator": "equals",
+      "comparison": false,
+      "failure_effect": "not_match",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["eandc-akron-dreams", "akron-dreams-criteria-2026"],
+      "buyer_reason_fail": "Akron Dreams requires the buyer not to have been a property owner during the prior three years.",
+      "buyer_reason_missing": "We need to know whether any applicable buyer owned property during the prior three years."
+    },
+    {
+      "rule_id": "owner-occupied",
+      "fact_keys": ["occupancy.intended"],
+      "operator": "equals",
+      "comparison": "primary_residence",
+      "failure_effect": "not_match",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["eandc-akron-dreams", "akron-dreams-criteria-2026"],
+      "buyer_reason_fail": "The home must be owner occupied.",
+      "buyer_reason_missing": "We need to know whether the home will be your primary residence."
+    },
+    {
+      "rule_id": "credit-score-620",
+      "fact_keys": ["credit.score"],
+      "operator": "gte",
+      "comparison": 620,
+      "failure_effect": "not_match",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["akron-dreams-criteria-2026"],
+      "buyer_reason_fail": "The published criteria list a minimum credit score of 620.",
+      "buyer_reason_missing": "An approximate credit-score band is needed to screen the published 620 minimum."
+    },
+    {
+      "rule_id": "income-by-household-size",
+      "fact_keys": ["household.size", "household.gross_income"],
+      "operator": "lte_lookup",
+      "comparison": {"table": {"1": 54400, "2": 62200, "3": 69950, "4": 77701, "5": 83950, "6": 90150, "7": 96350, "8": 102600}, "key_fact": "household.size", "value_fact": "household.gross_income"},
+      "failure_effect": "not_match",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["eandc-akron-dreams", "akron-dreams-criteria-2026"],
+      "buyer_reason_fail": "Known household income appears above the published Akron Dreams 2026 limit for that household size.",
+      "buyer_reason_missing": "Household size and approximate gross household income are needed to screen the published income limit."
+    },
+    {
+      "rule_id": "mortgage-preapproval",
+      "fact_keys": ["financing.preapproved"],
+      "operator": "equals",
+      "comparison": true,
+      "failure_effect": "worth_checking",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["akron-dreams-criteria-2026"],
+      "buyer_reason_fail": "Written mortgage preapproval is required, but this can potentially be completed before applying.",
+      "buyer_reason_missing": "We need to know whether written mortgage preapproval has been obtained."
+    },
+    {
+      "rule_id": "fixed-30-year-mortgage",
+      "fact_keys": ["financing.fixed_rate_30_year"],
+      "operator": "equals",
+      "comparison": true,
+      "failure_effect": "worth_checking",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["akron-dreams-criteria-2026"],
+      "buyer_reason_fail": "The published criteria require preapproval for a fixed-rate 30-year mortgage.",
+      "buyer_reason_missing": "The planned mortgage term/rate structure is needed to screen this requirement."
+    },
+    {
+      "rule_id": "homebuyer-education",
+      "fact_keys": ["education.hud_homebuyer_8hr_current"],
+      "operator": "equals",
+      "comparison": true,
+      "failure_effect": "worth_checking",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["eandc-akron-dreams", "akron-dreams-criteria-2026"],
+      "buyer_reason_fail": "Required homebuyer education is not yet complete, but it may be possible to complete it before program approval.",
+      "buyer_reason_missing": "We need to know whether the required HUD-approved homebuyer education has been completed."
+    },
+    {
+      "rule_id": "bankruptcy-foreclosure-lookback",
+      "fact_keys": ["credit.bankruptcy_or_foreclosure_within_2_years"],
+      "operator": "equals",
+      "comparison": false,
+      "failure_effect": "not_match",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["eandc-akron-dreams", "akron-dreams-criteria-2026"],
+      "buyer_reason_fail": "The published criteria state no bankruptcy or foreclosure during the prior two years.",
+      "buyer_reason_missing": "This program specifically requires confirmation about bankruptcy or foreclosure during the prior two years."
+    },
+    {
+      "rule_id": "liquid-assets",
+      "fact_keys": ["household.liquid_assets"],
+      "operator": "lte",
+      "comparison": 15000,
+      "failure_effect": "worth_checking",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["akron-dreams-criteria-2026"],
+      "buyer_reason_fail": "Published criteria cap retained liquid assets at $15,000 and require excess funds to be applied to the purchase; this needs administrator review rather than an automatic rejection.",
+      "buyer_reason_missing": "Approximate liquid assets are relevant to this program's published $15,000 retained-asset rule."
+    },
+    {
+      "rule_id": "property-units",
+      "fact_keys": ["property.units"],
+      "operator": "in",
+      "comparison": [1, 2],
+      "failure_effect": "not_match",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["akron-dreams-criteria-2026"],
+      "buyer_reason_fail": "Published criteria allow a one- or two-unit property.",
+      "buyer_reason_missing": "We need the property's number of dwelling units."
+    },
+    {
+      "rule_id": "funding-availability",
+      "fact_keys": ["program.akron_dreams_funding_confirmed"],
+      "operator": "equals",
+      "comparison": true,
+      "failure_effect": "worth_checking",
+      "missing_effect": "worth_checking",
+      "external_dependency": true,
+      "source_ids": ["eandc-akron-dreams"],
+      "buyer_reason_missing": "Funding is first-come, first-served and must be confirmed with EANDC."
+    },
+    {
+      "rule_id": "current-property-value-limit",
+      "fact_keys": ["property.purchase_price", "program.akron_dreams_current_value_limit"],
+      "operator": "lte_lookup",
+      "comparison": {"table": {}, "key_fact": "program.akron_dreams_current_value_limit", "value_fact": "property.purchase_price"},
+      "failure_effect": "not_match",
+      "missing_effect": "worth_checking",
+      "external_dependency": true,
+      "source_ids": ["akron-dreams-criteria-2026"],
+      "buyer_reason_missing": "The published criteria use a current Akron median-price-based property value limit; HBE should confirm the current dollar threshold with the administrator before relying on it."
+    }
+  ],
+  "authoritative_sources": [
+    {
+      "source_id": "eandc-akron-dreams",
+      "label": "Akron Dreams 2026 program page",
+      "url": "https://www.eandc.org/akrondreams",
+      "publisher": "East Akron Neighborhood Development Corporation",
+      "document_title": "Akron Dreams 2026",
+      "effective_date": null,
+      "retrieved_date": "2026-09-01",
+      "version_note": "Live administrator page reviewed September 1, 2026."
+    },
+    {
+      "source_id": "akron-dreams-criteria-2026",
+      "label": "Akron Dreams 2026 Eligibility Criteria Form",
+      "url": "https://drive.google.com/file/d/1MytuOodh-yGcrGtXf3YUZIHPtbmhYdTx/view?usp=sharing",
+      "publisher": "East Akron Neighborhood Development Corporation / City of Akron",
+      "document_title": "Akron Dreams First Time Homebuyer Down Payment Assistance Program 2026 — Eligibility Criteria",
+      "effective_date": null,
+      "retrieved_date": "2026-09-01",
+      "version_note": "Criteria copy linked from/associated with the current program; HBE should preserve the administrator-hosted source URL when available."
+    }
+  ],
+  "last_verified_date": "2026-09-01",
+  "last_materially_changed_date": "2026-08-25",
+  "human_caveats": [
+    "Program launched in August 2026 and funds are first-come, first-served; availability requires frequent verification.",
+    "The published property-value rule references 95% of Akron's median purchase price rather than giving a durable threshold in the criteria copy reviewed; do not hard-code an inferred dollar limit.",
+    "The liquid-asset rule is not modeled as an automatic exclusion when assets exceed $15,000 because the published language says excess funds must first be applied to the purchase.",
+    "Final eligibility is determined by the program administrator/lender, not HBE."
+  ]
+}

--- a/secure-platform/bimatrix/catalog/ohfa-down-payment-assistance.json
+++ b/secure-platform/bimatrix/catalog/ohfa-down-payment-assistance.json
@@ -1,0 +1,238 @@
+{
+  "program_id": "ohfa-down-payment-assistance",
+  "version": 1,
+  "name": "OHFA Down Payment Assistance",
+  "administrator": "Ohio Housing Finance Agency",
+  "summary_plain_english": "OHFA Down Payment Assistance can provide 3% of the purchase price with an eligible conventional OHFA loan or 3.5% with an eligible FHA, VA, or USDA-RD OHFA loan. It is an add-on to qualifying OHFA financing, not a stand-alone grant.",
+  "status": "open",
+  "benefit": {
+    "type": "forgivable_assistance",
+    "summary": "3% of purchase price for conventional OHFA loans or 3.5% for eligible FHA, VA, or USDA-RD OHFA loans. Assistance may be applied toward down payment, closing costs, or other eligible pre-closing expenses and is forgiven after seven years if program terms are satisfied.",
+    "amount_min": null,
+    "amount_max": null,
+    "amount_formula": "purchase_price * 0.03 for conventional; purchase_price * 0.035 for FHA/VA/USDA-RD"
+  },
+  "geography": {
+    "state": "OH",
+    "county_specific_income_and_purchase_price_limits": true,
+    "target_area_rules_may_change_first_time_requirement": true
+  },
+  "criteria": {
+    "eligible_loan_types": ["conventional", "FHA", "VA", "USDA-RD"],
+    "minimum_credit_scores": {
+      "conventional": 640,
+      "USDA-RD": 640,
+      "VA": 640,
+      "FHA": 650
+    },
+    "income_limits": "County- and target-area-specific OHFA limits apply.",
+    "purchase_price_limits": "County-specific OHFA limits apply.",
+    "debt_to_income": "Borrower must meet debt-to-income requirements for the applicable loan type.",
+    "primary_residence": true,
+    "first_time_path": "Generally the traditional first-time homebuyer pathway requires no ownership interest in a principal residence during the prior three years; qualified honorably discharged veterans and buyers purchasing in designated target areas can qualify without satisfying that ordinary first-time test.",
+    "repeat_buyer_path": "Repeat buyers may use the Next Home pathway if they meet its requirements.",
+    "homebuyer_education_required": true,
+    "approved_lender_required": true
+  },
+  "terms": {
+    "forgiveness_years": 7,
+    "repayment_if_sold_within_forgiveness_period": "OHFA states all assistance must be repaid if the home is sold within seven years under the standard DPA product.",
+    "reservation_and_lender_process_required": true
+  },
+  "tradeoffs": [
+    "OHFA mortgage rates depend on the homeownership product and whether down payment assistance is selected; rates change daily.",
+    "The DPA option can carry a higher mortgage rate than the comparable OHFA loan without assistance, so the assistance amount must be compared with monthly payment and long-term borrowing cost.",
+    "For example, OHFA's rate sheet updated August 31, 2026 showed the traditional first-time FHA/VA/USDA-RD rate at 6.375% without OHFA assistance versus 6.875% with 3.5% DPA, and conventional at 6.625% without assistance versus 7.125% with 3% DPA. These figures are a dated example only and must never be hard-coded as current pricing.",
+    "Income and purchase-price limits vary by county and target/non-target geography.",
+    "An OHFA-approved lender and an eligible underlying OHFA loan/product are required; screening alone cannot confirm underwriting or reservation availability."
+  ],
+  "rules": [
+    {
+      "rule_id": "ohio-property",
+      "fact_keys": ["target.state"],
+      "operator": "equals",
+      "comparison": "OH",
+      "failure_effect": "not_match",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["ohfa-homeownership-products"],
+      "buyer_reason_fail": "OHFA homebuyer assistance is for an eligible Ohio home purchase.",
+      "buyer_reason_missing": "We need the target state or property address."
+    },
+    {
+      "rule_id": "eligible-loan-type",
+      "fact_keys": ["financing.type"],
+      "operator": "in",
+      "comparison": ["conventional", "FHA", "VA", "USDA-RD"],
+      "failure_effect": "not_match",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["ohfa-homeownership-products", "ohfa-dpa-update"],
+      "buyer_reason_fail": "Current OHFA DPA is paired with eligible conventional, FHA, VA, or USDA-RD OHFA financing.",
+      "buyer_reason_missing": "We need the likely financing type to calculate the assistance percentage and screen credit requirements."
+    },
+    {
+      "rule_id": "credit-score-conventional-va-usda",
+      "fact_keys": ["financing.type", "credit.score"],
+      "operator": "gte_lookup",
+      "comparison": {"table": {"conventional": 640, "VA": 640, "USDA-RD": 640, "FHA": 650}, "key_fact": "financing.type", "value_fact": "credit.score"},
+      "failure_effect": "not_match",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["ohfa-rates", "ohfa-homeownership-products"],
+      "buyer_reason_fail": "The known credit score appears below OHFA's published minimum for the selected loan type.",
+      "buyer_reason_missing": "An approximate credit score and likely loan type are needed to screen OHFA's published minimum."
+    },
+    {
+      "rule_id": "primary-residence",
+      "fact_keys": ["occupancy.intended"],
+      "operator": "equals",
+      "comparison": "primary_residence",
+      "failure_effect": "not_match",
+      "missing_effect": "info_missing",
+      "external_dependency": false,
+      "source_ids": ["ohfa-homeownership-products", "ohfa-next-home"],
+      "buyer_reason_fail": "OHFA homebuyer programs are designed for an eligible primary-residence purchase.",
+      "buyer_reason_missing": "We need to know whether the property will be the buyer's primary residence."
+    },
+    {
+      "rule_id": "county-income-limit",
+      "fact_keys": ["target.county", "household.size", "household.gross_income", "property.target_area_status"],
+      "operator": "present",
+      "comparison": true,
+      "failure_effect": "worth_checking",
+      "missing_effect": "info_missing",
+      "external_dependency": true,
+      "source_ids": ["ohfa-limits", "ohfa-homeownership-products"],
+      "buyer_reason_missing": "OHFA income limits vary by county, household size, and target/non-target area; those facts and the current published limit table are needed for a deterministic screen.",
+      "hbe_caveat": "Replace this external placeholder with county-specific deterministic lookup rules as the five-county limits are imported and versioned."
+    },
+    {
+      "rule_id": "county-purchase-price-limit",
+      "fact_keys": ["target.county", "property.purchase_price", "property.target_area_status"],
+      "operator": "present",
+      "comparison": true,
+      "failure_effect": "worth_checking",
+      "missing_effect": "info_missing",
+      "external_dependency": true,
+      "source_ids": ["ohfa-limits"],
+      "buyer_reason_missing": "The current OHFA purchase-price limit for the property's county/area must be checked.",
+      "hbe_caveat": "Replace this external placeholder with deterministic county/area lookup data during the five-county limits work package."
+    },
+    {
+      "rule_id": "first-time-or-exception-path",
+      "fact_keys": ["household.primary_residence_owned_within_3_years", "buyer.honorably_discharged_veteran", "property.target_area_status", "program.ohfa_path"],
+      "operator": "present",
+      "comparison": true,
+      "failure_effect": "worth_checking",
+      "missing_effect": "info_missing",
+      "external_dependency": true,
+      "source_ids": ["ohfa-faq", "ohfa-homeownership-products", "ohfa-next-home"],
+      "buyer_reason_missing": "We need enough information to determine the applicable OHFA pathway: first-time homebuyer, veteran/target-area exception, or Next Home repeat-buyer path.",
+      "hbe_caveat": "Path selection should become deterministic once First-Time, Target Area, and Next Home are modeled as linked canonical products."
+    },
+    {
+      "rule_id": "approved-lender",
+      "fact_keys": ["financing.ohfa_approved_lender_confirmed"],
+      "operator": "equals",
+      "comparison": true,
+      "failure_effect": "worth_checking",
+      "missing_effect": "worth_checking",
+      "external_dependency": true,
+      "source_ids": ["ohfa-homeownership-products"],
+      "buyer_reason_missing": "OHFA loans are originated through participating lenders; lender participation must be confirmed."
+    },
+    {
+      "rule_id": "dti-underwriting",
+      "fact_keys": ["financing.dti_approved"],
+      "operator": "equals",
+      "comparison": true,
+      "failure_effect": "worth_checking",
+      "missing_effect": "worth_checking",
+      "external_dependency": true,
+      "source_ids": ["ohfa-homeownership-products"],
+      "buyer_reason_missing": "Debt-to-income eligibility depends on the loan type and lender underwriting."
+    },
+    {
+      "rule_id": "current-rate-tradeoff-reviewed",
+      "fact_keys": ["program.ohfa_current_rate_comparison_reviewed"],
+      "operator": "equals",
+      "comparison": true,
+      "failure_effect": "worth_checking",
+      "missing_effect": "worth_checking",
+      "external_dependency": true,
+      "source_ids": ["ohfa-rates"],
+      "buyer_reason_missing": "Before recommending DPA, compare the current OHFA rate with assistance against the comparable no-assistance rate and total borrowing cost."
+    }
+  ],
+  "authoritative_sources": [
+    {
+      "source_id": "ohfa-homeownership-products",
+      "label": "OHFA Homeownership Products",
+      "url": "https://www.hudexchange.ohiohome.org/homebuyers.aspx",
+      "publisher": "Ohio Housing Finance Agency",
+      "document_title": "Homeownership Products",
+      "effective_date": null,
+      "retrieved_date": "2026-09-01",
+      "version_note": "Current OHFA product/eligibility overview."
+    },
+    {
+      "source_id": "ohfa-rates",
+      "label": "OHFA Mortgage Rates",
+      "url": "https://ohiohome.org/rates/",
+      "publisher": "Ohio Housing Finance Agency",
+      "document_title": "Mortgage Rates",
+      "effective_date": "2026-08-31",
+      "retrieved_date": "2026-09-01",
+      "version_note": "Rate sheet states rates change daily and are updated weekdays at 9:30 AM."
+    },
+    {
+      "source_id": "ohfa-limits",
+      "label": "OHFA Purchase Price & Income Limits",
+      "url": "https://ohiohome.org/limits/default.aspx",
+      "publisher": "Ohio Housing Finance Agency",
+      "document_title": "Purchase Price & Income Limits",
+      "effective_date": null,
+      "retrieved_date": "2026-09-01",
+      "version_note": "County and target/non-target limits must be separately versioned for deterministic evaluation."
+    },
+    {
+      "source_id": "ohfa-faq",
+      "label": "OHFA Homeownership Frequently Asked Questions",
+      "url": "https://ohiohome.org/partners/faqs.aspx",
+      "publisher": "Ohio Housing Finance Agency",
+      "document_title": "Homeownership Frequently Asked Questions",
+      "effective_date": null,
+      "retrieved_date": "2026-09-01",
+      "version_note": "Used for first-time buyer definition and target-area/veteran exceptions."
+    },
+    {
+      "source_id": "ohfa-dpa-update",
+      "label": "OHFA DPA program update",
+      "url": "https://ohiohome.org/partners/lenders.aspx",
+      "publisher": "Ohio Housing Finance Agency",
+      "document_title": "Lender Resources — DPA Updates",
+      "effective_date": "2025-07-01",
+      "retrieved_date": "2026-09-01",
+      "version_note": "Confirms current 3% conventional and 3.5% government-loan DPA structure."
+    },
+    {
+      "source_id": "ohfa-next-home",
+      "label": "OHFA Next Home",
+      "url": "https://ohiohome.org/partners/fillable/NextHome_Fillable.pdf",
+      "publisher": "Ohio Housing Finance Agency",
+      "document_title": "Next Home",
+      "effective_date": "2025-07-01",
+      "retrieved_date": "2026-09-01",
+      "version_note": "Repeat-buyer pathway source; revised July 1, 2025."
+    }
+  ],
+  "last_verified_date": "2026-09-01",
+  "last_materially_changed_date": "2025-07-01",
+  "human_caveats": [
+    "This record models the DPA add-on. It must eventually link to separate canonical OHFA base-product/path records rather than duplicating all first-time, target-area, veteran, and Next Home logic.",
+    "Current county income and purchase-price tables are not yet imported into the catalog; until they are, those checks remain explicit external dependencies and should not produce `likely`.",
+    "OHFA pricing changes daily. The August 31, 2026 rates are stored only as an example of the fiduciary tradeoff and must not be presented as a current quote after that date.",
+    "Final loan qualification, program reservation, and underwriting are determined by the participating lender/OHFA, not HBE."
+  ]
+}

--- a/secure-platform/deploy.ps1
+++ b/secure-platform/deploy.ps1
@@ -28,8 +28,8 @@ if ($config -match 'REPLACE_[A-Z0-9_]+') {
 if ($config -notmatch '(?m)^keep_vars\s*=\s*true\s*$') {
   throw 'Deployment preflight failed: keep_vars=true is required so live dashboard-managed Access variables are preserved.'
 }
-if ($config -notmatch '(?m)^main\s*=\s*"src/issue29-production-worker\.js"\s*$') {
-  throw 'Deployment preflight failed: Wrangler must point to the final Issue 29 production wrapper.'
+if ($config -notmatch '(?m)^main\s*=\s*"src/issue33-production-worker\.js"\s*$') {
+  throw 'Deployment preflight failed: Wrangler must point to the final Issue 33 production wrapper.'
 }
 Set-Content -Path $tempConfigPath -Value $config -Encoding UTF8
 Write-Host "Using existing D1 database $dbName ($($db.uuid))"
@@ -39,8 +39,9 @@ try {
   npx --yes wrangler@latest d1 execute $dbName --remote --file=schema.sql --config $tempConfigPath
   npx --yes wrangler@latest d1 execute $dbName --remote --file=schema-stage4.sql --config $tempConfigPath
   npx --yes wrangler@latest d1 execute $dbName --remote --file=schema-issue29.sql --config $tempConfigPath
+  npx --yes wrangler@latest d1 execute $dbName --remote --file=schema-issue33.sql --config $tempConfigPath
 
-  Write-Host '4/6 Running local source and Issue 29 checks...'
+  Write-Host '4/6 Running local source, Issue 29, and Issue 33 checks...'
   node --check src/worker.js
   node --check src/ui-worker.js
   node --check src/portal-worker.js
@@ -61,7 +62,11 @@ try {
   node --check src/issue29-ui.js
   node --check src/issue29-convergence-worker.js
   node --check src/issue29-production-worker.js
+  node --check src/bimatrix/evaluator.js
+  node --check src/bimatrix/freshness.js
+  node --check src/issue33-production-worker.js
   node --test tests/issue29.test.mjs
+  node --test tests/bimatrix.test.mjs
   if (Select-String -Path src/worker.js -Pattern 'donald-kelley|localStorage|buyer_token_hash' -Quiet) {
     throw 'Security/source check failed: legacy buyer-specific or browser-local journey code detected.'
   }
@@ -88,6 +93,9 @@ try {
   if (-not $health.issue29 -or $health.issue29.stages -ne 17) {
     throw 'Issue 29 health verification failed: expected the 17-stage convergence layer.'
   }
+  if (-not $health.issue33 -or -not $health.issue33.bimatrix -or -not $health.issue33.buyer_refresh) {
+    throw 'Issue 33 health verification failed: expected BIMatrix and buyer refresh support.'
+  }
 
   Write-Host ''
   Write-Host 'LIVE' -ForegroundColor Green
@@ -96,7 +104,9 @@ try {
   Write-Host "HBE Portal:    $buyerBaseUrl/hbe"
   Write-Host "Health:        $buyerBaseUrl/health"
   Write-Host ''
-  Write-Host 'Issue 29 convergence enabled: 17-stage journey, household story/compass, What''s Next, per-buyer privacy, and After the Keys.' -ForegroundColor Green
+  Write-Host 'Issue 29 convergence remains enabled: 17-stage journey, household story/compass, What''s Next, per-buyer privacy, and After the Keys.' -ForegroundColor Green
+  Write-Host 'Issue 33 BIMatrix enabled: authenticated Possible Assistance, Last updated / Update now freshness check, canonical rules, and D1 household isolation.' -ForegroundColor Green
+  Write-Host 'Buyer-triggered freshness checks do not silently change canonical rules; unexpected source changes are sent to HBE review state.' -ForegroundColor Yellow
   Write-Host 'MLS adapter remains disconnected/unapproved until MLS Now approves the exact feed and encrypted credentials are configured.' -ForegroundColor Yellow
   Write-Host 'HBE Portal must remain protected by Cloudflare Access.' -ForegroundColor Yellow
   Write-Host 'Sensitive uploads remain disabled until /sensitive* has fresh email-OTP Access protection.' -ForegroundColor Yellow

--- a/secure-platform/schema-issue33.sql
+++ b/secure-platform/schema-issue33.sql
@@ -1,7 +1,5 @@
 -- Issue #33 Buyer Incentive Matrix schema (additive).
 -- Apply AFTER schema.sql and schema-issue29.sql on the target D1.
--- This migration is design scaffolding only until reviewed. Do not apply to
--- production D1 with real Buyer Experience rows from an unreviewed deploy.
 PRAGMA foreign_keys = ON;
 
 CREATE TABLE IF NOT EXISTS bimatrix_screenings (
@@ -59,8 +57,20 @@ CREATE TABLE IF NOT EXISTS bimatrix_hbe_annotations (
   FOREIGN KEY (case_id) REFERENCES buyer_cases(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS bimatrix_freshness_checks (
+  id TEXT PRIMARY KEY,
+  case_id TEXT NOT NULL,
+  requested_by_buyer_id TEXT,
+  checked_at TEXT NOT NULL,
+  result TEXT NOT NULL CHECK (result IN ('current','review_pending','unavailable')),
+  details_json TEXT NOT NULL DEFAULT '[]',
+  FOREIGN KEY (case_id) REFERENCES buyer_cases(id) ON DELETE CASCADE,
+  FOREIGN KEY (requested_by_buyer_id) REFERENCES buyers(id) ON DELETE SET NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_bimatrix_screenings_status ON bimatrix_screenings(status, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_bimatrix_facts_case ON bimatrix_facts(case_id, fact_key);
 CREATE INDEX IF NOT EXISTS idx_bimatrix_results_case_class ON bimatrix_results(case_id, classification, evaluated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_bimatrix_results_program ON bimatrix_results(program_id, program_version);
 CREATE INDEX IF NOT EXISTS idx_bimatrix_annotations_case ON bimatrix_hbe_annotations(case_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_bimatrix_freshness_case ON bimatrix_freshness_checks(case_id, checked_at DESC);

--- a/secure-platform/src/bimatrix/evaluator.js
+++ b/secure-platform/src/bimatrix/evaluator.js
@@ -1,0 +1,140 @@
+const CLASSIFICATIONS = new Set(['likely', 'worth_checking', 'not_match', 'info_missing']);
+
+function hasFact(facts, key) {
+  return Object.prototype.hasOwnProperty.call(facts, key) && facts[key] !== null && facts[key] !== undefined && facts[key] !== '';
+}
+
+function compare(rule, facts) {
+  const keys = rule.fact_keys || [];
+  const missing = keys.filter((key) => !hasFact(facts, key));
+  if (missing.length) return { outcome: 'missing', missing };
+
+  const value = facts[keys[0]];
+  const comparison = rule.comparison;
+
+  switch (rule.operator) {
+    case 'present':
+      return { outcome: 'pass' };
+    case 'equals':
+      return { outcome: Object.is(value, comparison) ? 'pass' : 'fail' };
+    case 'not_equals':
+      return { outcome: !Object.is(value, comparison) ? 'pass' : 'fail' };
+    case 'in':
+      return { outcome: Array.isArray(comparison) && comparison.includes(value) ? 'pass' : 'fail' };
+    case 'not_in':
+      return { outcome: Array.isArray(comparison) && !comparison.includes(value) ? 'pass' : 'fail' };
+    case 'gte':
+      return { outcome: Number(value) >= Number(comparison) ? 'pass' : 'fail' };
+    case 'lte':
+      return { outcome: Number(value) <= Number(comparison) ? 'pass' : 'fail' };
+    case 'between_inclusive': {
+      const [min, max] = comparison || [];
+      return { outcome: Number(value) >= Number(min) && Number(value) <= Number(max) ? 'pass' : 'fail' };
+    }
+    case 'lte_lookup':
+    case 'gte_lookup': {
+      const table = comparison?.table || {};
+      const keyFact = comparison?.key_fact;
+      const valueFact = comparison?.value_fact;
+      if (!keyFact || !valueFact || !hasFact(facts, keyFact) || !hasFact(facts, valueFact)) {
+        const lookupMissing = [keyFact, valueFact].filter((key) => key && !hasFact(facts, key));
+        return { outcome: 'missing', missing: lookupMissing.length ? lookupMissing : keys };
+      }
+      const threshold = table[String(facts[keyFact])];
+      if (threshold === undefined || threshold === null) return { outcome: 'unresolved' };
+      const actual = Number(facts[valueFact]);
+      const pass = rule.operator === 'lte_lookup' ? actual <= Number(threshold) : actual >= Number(threshold);
+      return { outcome: pass ? 'pass' : 'fail', threshold };
+    }
+    case 'geography_in':
+      return { outcome: Array.isArray(comparison) && comparison.includes(value) ? 'pass' : 'fail' };
+    default:
+      return { outcome: 'unresolved' };
+  }
+}
+
+export function evaluateProgram(program, facts, { evaluatedAt = new Date().toISOString() } = {}) {
+  if (!program || !Array.isArray(program.rules)) throw new TypeError('Program with rules[] is required');
+  if (!facts || typeof facts !== 'object') throw new TypeError('facts object is required');
+
+  const reasons = [];
+  const missingFactKeys = new Set();
+  const externalChecks = new Set();
+  let hasHardFailure = false;
+  let hasMissing = false;
+  let hasWorthChecking = false;
+
+  for (const rule of program.rules) {
+    const result = compare(rule, facts);
+    let effect = null;
+
+    if (result.outcome === 'fail') {
+      effect = rule.failure_effect;
+      if (effect === 'not_match') hasHardFailure = true;
+      if (effect === 'worth_checking') hasWorthChecking = true;
+    } else if (result.outcome === 'missing') {
+      effect = rule.missing_effect;
+      for (const key of result.missing || rule.fact_keys || []) missingFactKeys.add(key);
+      if (effect === 'info_missing') hasMissing = true;
+      if (effect === 'worth_checking') hasWorthChecking = true;
+    } else if (result.outcome === 'unresolved') {
+      effect = 'worth_checking';
+      hasWorthChecking = true;
+    }
+
+    if (rule.external_dependency) {
+      externalChecks.add(rule.rule_id);
+      if (result.outcome === 'pass') hasWorthChecking = true;
+    }
+
+    reasons.push({
+      rule_id: rule.rule_id,
+      outcome: rule.external_dependency && result.outcome === 'pass' ? 'external' : result.outcome,
+      effect,
+      fact_keys: rule.fact_keys || [],
+      threshold: result.threshold ?? null
+    });
+  }
+
+  let classification;
+  if (hasHardFailure) classification = 'not_match';
+  else if (hasMissing) classification = 'info_missing';
+  else if (hasWorthChecking || externalChecks.size) classification = 'worth_checking';
+  else classification = 'likely';
+
+  if (!CLASSIFICATIONS.has(classification)) throw new Error('Invalid classification');
+
+  if (['paused', 'exhausted', 'unknown'].includes(program.status) && classification === 'likely') {
+    classification = 'worth_checking';
+  }
+  if (['closed', 'retired'].includes(program.status)) {
+    classification = 'not_match';
+    reasons.unshift({
+      rule_id: 'program-availability',
+      outcome: 'fail',
+      effect: 'not_match',
+      fact_keys: [],
+      threshold: null
+    });
+  }
+
+  return {
+    program_id: program.program_id,
+    program_version: String(program.version),
+    classification,
+    evaluated_at: evaluatedAt,
+    reasons,
+    missing_fact_keys: [...missingFactKeys].sort(),
+    external_checks: [...externalChecks].sort()
+  };
+}
+
+export function assistanceAmount(program, facts) {
+  if (program.program_id !== 'ohfa-down-payment-assistance') return null;
+  const price = Number(facts['property.purchase_price']);
+  const loanType = facts['financing.type'];
+  if (!Number.isFinite(price) || price <= 0 || !loanType) return null;
+  if (loanType === 'conventional') return Math.round(price * 0.03 * 100) / 100;
+  if (['FHA', 'VA', 'USDA-RD'].includes(loanType)) return Math.round(price * 0.035 * 100) / 100;
+  return null;
+}

--- a/secure-platform/src/bimatrix/freshness.js
+++ b/secure-platform/src/bimatrix/freshness.js
@@ -1,0 +1,220 @@
+import { assertMutationCsrf, caseIdForBuyer } from '../household-state.js';
+
+const enc = new TextEncoder();
+export const BIMATRIX_CANONICAL_UPDATED = 'September 1, 2026';
+
+export const CURRENT_PROGRAM_SOURCES = [
+  {
+    source_id: 'eandc-akron-dreams',
+    label: 'Akron Dreams',
+    url: 'https://www.eandc.org/akrondreams',
+    markers: ['akron dreams', '7,500']
+  },
+  {
+    source_id: 'ohfa-dpa-lender-updates',
+    label: 'OHFA Down Payment Assistance',
+    url: 'https://www.ohiohome.org/partners/lenders.aspx',
+    markers: ['down payment assistance', '3%', '3.5%']
+  }
+];
+
+export function evaluateSourceText(source, status, text) {
+  if (!(status >= 200 && status < 400)) {
+    return { source_id: source.source_id, label: source.label, outcome: 'unavailable', http_status: status || 0 };
+  }
+  const normalized = String(text || '').toLowerCase().replace(/\s+/g, ' ');
+  const missing = source.markers.filter(marker => !normalized.includes(marker.toLowerCase()));
+  return {
+    source_id: source.source_id,
+    label: source.label,
+    outcome: missing.length ? 'review_pending' : 'current',
+    http_status: status,
+    missing_markers: missing
+  };
+}
+
+export function summarizeFreshness(results) {
+  if (results.some(r => r.outcome === 'unavailable')) return 'unavailable';
+  if (results.some(r => r.outcome === 'review_pending')) return 'review_pending';
+  return 'current';
+}
+
+export async function handleBuyerBimatrixRefresh(request, env) {
+  if (!env?.BUYER_DB) return unavailable();
+  const auth = await getBuyerSession(request, env);
+  if (!auth) return redirect('/login');
+
+  const sessionToken = getCookie(request, 'hbe_session');
+  const form = await request.formData();
+  if (!await assertMutationCsrf(request, form.get('csrf'), sessionToken)) return forbidden('CSRF rejected.');
+
+  const caseId = await caseIdForBuyer(env, auth.buyer.id);
+  if (!caseId) return redirect('/portal');
+
+  const recent = await env.BUYER_DB.prepare(`
+    SELECT checked_at,result FROM bimatrix_freshness_checks
+    WHERE case_id=? ORDER BY checked_at DESC LIMIT 1`).bind(caseId).first();
+  if (recent?.checked_at && (Date.now() - Date.parse(recent.checked_at)) < 5 * 60 * 1000) {
+    return redirect('/portal#possible-assistance');
+  }
+
+  const checkedAt = new Date().toISOString();
+  const details = [];
+  for (const source of CURRENT_PROGRAM_SOURCES) {
+    try {
+      const response = await fetch(source.url, {
+        method: 'GET',
+        redirect: 'follow',
+        headers: {
+          'Accept': 'text/html,application/xhtml+xml,application/pdf;q=0.8,*/*;q=0.5',
+          'User-Agent': 'HomeBuyer-Experts-BIMatrix-Freshness/1.0'
+        }
+      });
+      const text = await response.text();
+      details.push(evaluateSourceText(source, response.status, text));
+    } catch (err) {
+      details.push({ source_id: source.source_id, label: source.label, outcome: 'unavailable', http_status: 0, error: String(err?.message || 'fetch failed').slice(0, 240) });
+    }
+  }
+
+  const result = summarizeFreshness(details);
+  const id = crypto.randomUUID();
+  await env.BUYER_DB.prepare(`
+    INSERT INTO bimatrix_freshness_checks
+      (id,case_id,requested_by_buyer_id,checked_at,result,details_json)
+    VALUES (?,?,?,?,?,?)`).bind(
+      id,
+      caseId,
+      auth.buyer.id,
+      checkedAt,
+      result,
+      JSON.stringify(details)
+    ).run();
+
+  return redirect('/portal#possible-assistance');
+}
+
+export async function buyerBimatrixPanel(request, env, csrfField = '') {
+  if (!env?.BUYER_DB) return renderBimatrixPanel({ csrfField });
+  const auth = await getBuyerSession(request, env);
+  if (!auth) return '';
+  const caseId = await caseIdForBuyer(env, auth.buyer.id);
+  let latest = null;
+  if (caseId) {
+    latest = await env.BUYER_DB.prepare(`
+      SELECT checked_at,result FROM bimatrix_freshness_checks
+      WHERE case_id=? ORDER BY checked_at DESC LIMIT 1`).bind(caseId).first();
+  }
+  return renderBimatrixPanel({ csrfField, latest });
+}
+
+export function renderBimatrixPanel({ csrfField = '', latest = null } = {}) {
+  let status = '';
+  if (latest?.result === 'current') {
+    status = `<p class="bimatrix-check current">Current sources checked: <strong>${escapeHtml(formatTimestamp(latest.checked_at))}</strong> ✓</p>`;
+  } else if (latest?.result === 'review_pending') {
+    status = '<p class="bimatrix-check pending">New information found — HBE review pending</p>';
+  } else if (latest?.result === 'unavailable') {
+    status = '<p class="bimatrix-check pending">Some sources could not be verified — HBE review pending</p>';
+  }
+
+  return `<section class="bimatrix-panel" id="possible-assistance" aria-labelledby="bimatrix-title">
+    <div class="bimatrix-head">
+      <div>
+        <p class="bimatrix-kicker">Possible Assistance</p>
+        <h2 id="bimatrix-title">Buyer Incentive Matrix</h2>
+        <p>Browse possible assistance without answering additional financial or eligibility questions. Final eligibility is determined by each program, lender, or administrator.</p>
+      </div>
+      <form method="post" action="/api/portal/bimatrix-refresh" class="bimatrix-update-form">
+        ${csrfField}
+        <span><strong>Last updated:</strong> ${BIMATRIX_CANONICAL_UPDATED}</span>
+        <button type="submit">Update now</button>
+      </form>
+    </div>
+    ${status}
+    <div class="bimatrix-grid">
+      <article class="bimatrix-card">
+        <h3>Akron Dreams 2026</h3>
+        <p><strong>Potential benefit:</strong> up to $7,500 in forgivable down-payment/closing-cost assistance.</p>
+        <p><strong>General fit:</strong> first-time buyer, owner-occupied property inside Akron, plus published income, credit, financing, education, asset and property requirements.</p>
+        <p class="bimatrix-tradeoff"><strong>Consider:</strong> five-year deed restriction, second-mortgage lien, buyer contribution and first-come funding.</p>
+        <a href="https://www.eandc.org/akrondreams" target="_blank" rel="noopener noreferrer">More details</a>
+      </article>
+      <article class="bimatrix-card">
+        <h3>OHFA Down Payment Assistance</h3>
+        <p><strong>Potential benefit:</strong> 3% for conventional loans or 3.5% for FHA, VA and USDA government loans under current OHFA terms.</p>
+        <p><strong>General fit:</strong> available through qualifying OHFA mortgage pathways, subject to income, purchase-price, credit, lender and program requirements.</p>
+        <p class="bimatrix-tradeoff"><strong>Consider:</strong> assistance can affect mortgage pricing. Compare rate, payment, cash required, forgiveness/repayment and long-term cost.</p>
+        <a href="https://www.ohiohome.org/partners/lenders.aspx" target="_blank" rel="noopener noreferrer">More details</a>
+      </article>
+    </div>
+    <p class="bimatrix-optin"><strong>Want to see what you may qualify for?</strong> Eligibility screening will remain a separate, optional step and will reuse information HBE already has before asking anything new.</p>
+  </section>`;
+}
+
+export const BIMATRIX_CSS = `<style id="issue33-bimatrix-css">
+.bimatrix-panel{margin:1.25rem 0;padding:1.1rem;border:1px solid #d8d4ca;border-radius:14px;background:#fffdf8;color:#2c2c2c}
+.bimatrix-head{display:flex;gap:1rem;justify-content:space-between;align-items:flex-start;flex-wrap:wrap}
+.bimatrix-kicker{margin:0 0 .15rem;text-transform:uppercase;letter-spacing:.08em;font-size:.74rem;font-weight:700;color:#2d5a3d}
+.bimatrix-panel h2{margin:.1rem 0 .45rem;color:#1a1a2e}.bimatrix-panel h3{margin:.1rem 0 .45rem;color:#1a1a2e}
+.bimatrix-update-form{display:flex;gap:.6rem;align-items:center;flex-wrap:wrap;padding:.65rem .75rem;border:1px solid #d8d4ca;border-radius:10px;background:#faf9f6}
+.bimatrix-update-form button{border:0;border-radius:8px;background:#2d5a3d;color:#fff;padding:.58rem .8rem;font-weight:700;cursor:pointer}
+.bimatrix-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:.85rem;margin-top:.9rem}
+.bimatrix-card{border:1px solid #e0ddd5;border-radius:12px;padding:.9rem;background:#fff}.bimatrix-card p{line-height:1.45}.bimatrix-card a{font-weight:700}
+.bimatrix-tradeoff{background:#faf6eb;border-left:3px solid #9b7a32;padding:.55rem .65rem}
+.bimatrix-check{margin:.75rem 0 0;padding:.55rem .7rem;border-radius:8px}.bimatrix-check.current{background:#eef7f0}.bimatrix-check.pending{background:#fff5dc}
+.bimatrix-optin{margin:1rem 0 0;padding-top:.8rem;border-top:1px solid #e0ddd5}
+@media(max-width:560px){.bimatrix-update-form{width:100%;justify-content:space-between}.bimatrix-update-form button{width:100%}}
+</style>`;
+
+function formatTimestamp(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'just now';
+  return new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short', timeZone: 'America/New_York' }).format(date);
+}
+
+async function getBuyerSession(request, env) {
+  const token = getCookie(request, 'hbe_session');
+  if (!token) return null;
+  const now = new Date().toISOString();
+  const row = await env.BUYER_DB.prepare(`SELECT s.id AS session_id,s.buyer_id,s.expires_at,b.*
+    FROM buyer_sessions s JOIN buyers b ON b.id=s.buyer_id
+    WHERE s.token_hash=? AND s.expires_at>? LIMIT 1`).bind(await sha256(token), now).first();
+  if (!row) return null;
+  return { session: { id: row.session_id, buyer_id: row.buyer_id }, buyer: row };
+}
+
+function getCookie(request, name) {
+  const raw = request.headers.get('cookie') || '';
+  for (const part of raw.split(';')) {
+    const [key, ...rest] = part.trim().split('=');
+    if (key === name) return decodeURIComponent(rest.join('='));
+  }
+  return '';
+}
+
+async function sha256(value) {
+  const digest = await crypto.subtle.digest('SHA-256', enc.encode(value));
+  return Array.from(new Uint8Array(digest), b => b.toString(16).padStart(2, '0')).join('');
+}
+
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, ch => ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' }[ch]));
+}
+
+function securityHeaders(contentType) {
+  return new Headers({
+    'content-type': contentType,
+    'cache-control': 'no-store',
+    'x-robots-tag': 'noindex, nofollow',
+    'x-frame-options': 'DENY',
+    'referrer-policy': 'no-referrer'
+  });
+}
+function redirect(location) {
+  const headers = securityHeaders('text/plain; charset=utf-8');
+  headers.set('location', location);
+  return new Response('', { status: 303, headers });
+}
+function forbidden(message) { return new Response(message, { status: 403, headers: securityHeaders('text/plain; charset=utf-8') }); }
+function unavailable() { return new Response('Buyer database is not bound in this environment.', { status: 503, headers: securityHeaders('text/plain; charset=utf-8') }); }

--- a/secure-platform/src/issue33-production-worker.js
+++ b/secure-platform/src/issue33-production-worker.js
@@ -1,0 +1,68 @@
+import appWorker from './issue29-production-worker.js';
+import { mutationCsrfToken } from './household-state.js';
+import { BIMATRIX_CSS, buyerBimatrixPanel, handleBuyerBimatrixRefresh } from './bimatrix/freshness.js';
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+
+    if (request.method === 'POST' && url.pathname === '/api/portal/bimatrix-refresh') {
+      return handleBuyerBimatrixRefresh(request, env);
+    }
+
+    const response = await appWorker.fetch(request, env, ctx);
+    const headers = new Headers(response.headers);
+    const type = headers.get('content-type') || '';
+
+    if (request.method === 'GET' && url.pathname === '/health' && type.includes('application/json')) {
+      try {
+        const body = await response.json();
+        body.issue33 = { bimatrix: true, buyer_refresh: true, canonical_review: 'monthly' };
+        return new Response(JSON.stringify(body), { status: response.status, headers });
+      } catch {
+        return response;
+      }
+    }
+
+    if (!type.includes('text/html')) return response;
+    let text = await response.text();
+
+    if (request.method === 'GET' && url.pathname === '/portal' && response.status === 200) {
+      const token = getCookie(request, 'hbe_session');
+      const csrf = token ? await mutationCsrfToken(token) : '';
+      const csrfField = csrf ? `<input type="hidden" name="csrf" value="${escapeHtml(csrf)}">` : '';
+      const panel = await buyerBimatrixPanel(request, env, csrfField);
+      if (panel && !text.includes('id="possible-assistance"')) {
+        text = injectBeforeMainEnd(text, panel);
+      }
+    }
+
+    if (!text.includes('id="issue33-bimatrix-css"')) {
+      text = text.replace('</head>', `${BIMATRIX_CSS}</head>`);
+    }
+
+    return new Response(text, {
+      status: response.status,
+      statusText: response.statusText,
+      headers
+    });
+  }
+};
+
+function injectBeforeMainEnd(text, panel) {
+  const i = text.lastIndexOf('</main>');
+  return i >= 0 ? `${text.slice(0, i)}${panel}${text.slice(i)}` : text.replace('</body>', `${panel}</body>`);
+}
+
+function getCookie(request, name) {
+  const raw = request.headers.get('cookie') || '';
+  for (const part of raw.split(';')) {
+    const [key, ...rest] = part.trim().split('=');
+    if (key === name) return decodeURIComponent(rest.join('='));
+  }
+  return '';
+}
+
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, ch => ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' }[ch]));
+}

--- a/secure-platform/tests/bimatrix.test.mjs
+++ b/secure-platform/tests/bimatrix.test.mjs
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { evaluateProgram, assistanceAmount } from '../src/bimatrix/evaluator.js';
+
+const loadJson = async (path) => JSON.parse(await readFile(new URL(path, import.meta.url), 'utf8'));
+const akron = await loadJson('../bimatrix/catalog/akron-dreams.json');
+const ohfa = await loadJson('../bimatrix/catalog/ohfa-down-payment-assistance.json');
+
+test('Akron Dreams hard geography mismatch is not_match', () => {
+  const result = evaluateProgram(akron, {
+    'target.municipality': 'Canton',
+    'household.property_owner_within_3_years': false,
+    'occupancy.intended': 'primary_residence',
+    'credit.score': 700,
+    'household.size': 2,
+    'household.gross_income': 60000,
+    'financing.preapproved': true,
+    'financing.fixed_rate_30_year': true,
+    'education.hud_homebuyer_8hr_current': true,
+    'credit.bankruptcy_or_foreclosure_within_2_years': false,
+    'household.liquid_assets': 10000,
+    'property.units': 1,
+    'program.akron_dreams_funding_confirmed': true,
+    'property.purchase_price': 180000,
+    'program.akron_dreams_current_value_limit': 220000
+  }, { evaluatedAt: '2026-09-01T12:00:00Z' });
+  assert.equal(result.classification, 'not_match');
+  assert.ok(result.reasons.some(r => r.rule_id === 'akron-city-limits' && r.outcome === 'fail'));
+});
+
+test('Akron Dreams missing income produces info_missing and names facts', () => {
+  const result = evaluateProgram(akron, {
+    'target.municipality': 'Akron',
+    'household.property_owner_within_3_years': false,
+    'occupancy.intended': 'primary_residence',
+    'credit.score': 700
+  });
+  assert.equal(result.classification, 'info_missing');
+  assert.ok(result.missing_fact_keys.includes('household.size'));
+  assert.ok(result.missing_fact_keys.includes('household.gross_income'));
+});
+
+test('Akron Dreams clean known facts remains worth_checking until live external checks resolve', () => {
+  const result = evaluateProgram(akron, {
+    'target.municipality': 'Akron',
+    'household.property_owner_within_3_years': false,
+    'occupancy.intended': 'primary_residence',
+    'credit.score': 700,
+    'household.size': 2,
+    'household.gross_income': 60000,
+    'financing.preapproved': true,
+    'financing.fixed_rate_30_year': true,
+    'education.hud_homebuyer_8hr_current': true,
+    'credit.bankruptcy_or_foreclosure_within_2_years': false,
+    'household.liquid_assets': 10000,
+    'property.units': 1,
+    'program.akron_dreams_funding_confirmed': true,
+    'property.purchase_price': 180000,
+    'program.akron_dreams_current_value_limit': 220000
+  });
+  assert.equal(result.classification, 'worth_checking');
+  assert.ok(result.external_checks.includes('funding-availability'));
+});
+
+test('OHFA DPA computes 3% conventional and 3.5% government assistance', () => {
+  assert.equal(assistanceAmount(ohfa, { 'property.purchase_price': 200000, 'financing.type': 'conventional' }), 6000);
+  assert.equal(assistanceAmount(ohfa, { 'property.purchase_price': 200000, 'financing.type': 'FHA' }), 7000);
+  assert.equal(assistanceAmount(ohfa, { 'property.purchase_price': 200000, 'financing.type': 'VA' }), 7000);
+});
+
+test('OHFA DPA credit score below selected loan threshold is not_match', () => {
+  const result = evaluateProgram(ohfa, {
+    'target.state': 'OH',
+    'financing.type': 'FHA',
+    'credit.score': 640,
+    'occupancy.intended': 'primary_residence',
+    'target.county': 'Summit',
+    'household.size': 2,
+    'household.gross_income': 65000,
+    'property.target_area_status': 'non_target',
+    'property.purchase_price': 200000,
+    'household.primary_residence_owned_within_3_years': false,
+    'buyer.honorably_discharged_veteran': false,
+    'program.ohfa_path': 'first_time',
+    'financing.ohfa_approved_lender_confirmed': true,
+    'financing.dti_approved': true,
+    'program.ohfa_current_rate_comparison_reviewed': true
+  });
+  assert.equal(result.classification, 'not_match');
+  assert.ok(result.reasons.some(r => r.rule_id === 'credit-score-conventional-va-usda' && r.outcome === 'fail'));
+});
+
+test('OHFA DPA cannot become likely while county limits/path/rate remain external', () => {
+  const result = evaluateProgram(ohfa, {
+    'target.state': 'OH',
+    'financing.type': 'conventional',
+    'credit.score': 700,
+    'occupancy.intended': 'primary_residence',
+    'target.county': 'Summit',
+    'household.size': 2,
+    'household.gross_income': 65000,
+    'property.target_area_status': 'non_target',
+    'property.purchase_price': 200000,
+    'household.primary_residence_owned_within_3_years': false,
+    'buyer.honorably_discharged_veteran': false,
+    'program.ohfa_path': 'first_time',
+    'financing.ohfa_approved_lender_confirmed': true,
+    'financing.dti_approved': true,
+    'program.ohfa_current_rate_comparison_reviewed': true
+  });
+  assert.equal(result.classification, 'worth_checking');
+  assert.ok(result.external_checks.length >= 1);
+});

--- a/secure-platform/tests/bimatrix.test.mjs
+++ b/secure-platform/tests/bimatrix.test.mjs
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { evaluateProgram, assistanceAmount } from '../src/bimatrix/evaluator.js';
+import { evaluateSourceText, summarizeFreshness, renderBimatrixPanel } from '../src/bimatrix/freshness.js';
 
 const loadJson = async (path) => JSON.parse(await readFile(new URL(path, import.meta.url), 'utf8'));
 const akron = await loadJson('../bimatrix/catalog/akron-dreams.json');
@@ -111,4 +112,27 @@ test('OHFA DPA cannot become likely while county limits/path/rate remain externa
   });
   assert.equal(result.classification, 'worth_checking');
   assert.ok(result.external_checks.length >= 1);
+});
+
+test('freshness source verifier distinguishes current, changed, and unavailable', () => {
+  const source = { source_id: 'test', label: 'Test Program', markers: ['down payment assistance', '3.5%'] };
+  assert.equal(evaluateSourceText(source, 200, 'Down Payment Assistance is 3.5%').outcome, 'current');
+  assert.equal(evaluateSourceText(source, 200, 'Down Payment Assistance changed').outcome, 'review_pending');
+  assert.equal(evaluateSourceText(source, 503, '').outcome, 'unavailable');
+});
+
+test('freshness summary fails safely toward HBE review', () => {
+  assert.equal(summarizeFreshness([{ outcome: 'current' }, { outcome: 'current' }]), 'current');
+  assert.equal(summarizeFreshness([{ outcome: 'current' }, { outcome: 'review_pending' }]), 'review_pending');
+  assert.equal(summarizeFreshness([{ outcome: 'current' }, { outcome: 'unavailable' }]), 'unavailable');
+});
+
+test('BuyerUI panel uses final Last updated / Update now wording', () => {
+  const html = renderBimatrixPanel({ csrfField: '<input name="csrf" value="safe">' });
+  assert.match(html, /Last updated:/);
+  assert.match(html, />Update now</);
+  assert.match(html, /Possible Assistance/);
+  assert.match(html, /Akron Dreams 2026/);
+  assert.match(html, /OHFA Down Payment Assistance/);
+  assert.doesNotMatch(html, /Likely|Not a Match|Info Missing/);
 });

--- a/secure-platform/wrangler.toml
+++ b/secure-platform/wrangler.toml
@@ -1,5 +1,5 @@
 name = "hbe-buyer-platform"
-main = "src/issue29-production-worker.js"
+main = "src/issue33-production-worker.js"
 compatibility_date = "2026-08-26"
 workers_dev = false
 preview_urls = false


### PR DESCRIPTION
## Promoted to main
GitHub's draft-to-ready connector path failed with a GraphQL schema error, so after review and confirmation that the branch was a clean fast-forward from `main`, the reviewed head was promoted to `main` without force.

## Scope
First deployable Issue #33 Buyer Incentive Matrix package:
- canonical Akron Dreams 2026 + OHFA DPA seed records
- deterministic evaluator
- authenticated BuyerUI Possible Assistance panel
- **Last updated: <date> [Update now]**
- buyer-triggered authoritative-source freshness checks
- five-minute per-household freshness cache
- D1 freshness history and HBE-review-pending states
- Issue #33 production wrapper
- deploy script applies Issue #33 schema, tests Issue #29/#33, dry-runs Wrangler, deploys, and verifies health

## Security review
Buyer session + CSRF remain required; buyer financial/eligibility answers are not sent to external freshness sources; freshness records remain household-scoped in D1; external checks cannot silently mutate canonical rules.

## Production status
Code is on `main`. The secure Worker at `buyer.hbexperts.com` is deployed separately through the existing Cloudflare-authenticated `secure-platform/deploy.ps1` path; GitHub Pages does not deploy the private BuyerUI Worker.