### PR TITLE
Buyer-first clarity: review before submit

### DIFF
--- a/.github/workflows/secure-platform-ci.yml
+++ b/.github/workflows/secure-platform-ci.yml
@@ -1,0 +1,29 @@
+name: Secure Platform Buyer-First CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'secure-platform/**'
+      - '.github/workflows/secure-platform-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'secure-platform/**'
+      - '.github/workflows/secure-platform-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  buyer-first:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify production wrapper syntax
+        run: node --check secure-platform/src/issue33-production-worker.js
+
+      - name: Test buyer-first clarity and review flow
+        run: node --test secure-platform/tests/issue36.test.mjs

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,13 +1,15 @@
 ---
-title: "A Buyer Advocate for Decisions That Matter"
-description: "HomeBuyer Experts provides exclusive buyer representation designed to increase understanding, protect buyer agency, and help Northeast Ohio home buyers choose wisely."
+title: "We Help Home Buyers Make Better Decisions"
+description: "HomeBuyer Experts works only for home buyers in Northeast Ohio. We help you understand your options, protect your interests, and choose what is best for you."
 ---
 
-## A home purchase is a consequential decision.
+## We work only for home buyers.
 
-It involves money, risk, lifestyle, family, timing, uncertainty, and future possibilities — not just a property.
+We never represent the seller.
 
-**HomeBuyer Experts exists to help protect the quality of that decision.**
+That means our job is to help **you** understand the homes, the risks, the tradeoffs, and your choices before you make a major commitment.
+
+Sometimes the best choice is to move forward. Sometimes it is to negotiate differently, change the search, wait, or walk away.
 
 ---
 
@@ -15,18 +17,16 @@ It involves money, risk, lifestyle, family, timing, uncertainty, and future poss
 
 > **What is best for the buyer?**
 
-We represent buyers exclusively. We do not take listings.
+A home purchase can affect your money, family, time, work, and future for years. Good representation should make the decision clearer — not pressure you into making it faster.
 
-Our job is not to push a transaction toward closing. It is to help you understand your options, see important tradeoffs, protect your leverage, and make a choice you can own.
-
-Sometimes that means moving forward. Sometimes it means negotiating differently, changing the search, waiting, or walking away.
+We help you understand your options, investigate important questions, protect your leverage, and make a choice you can own.
 
 ---
 
-## The HBE Buyer Advantage™
+## What HBE Adds
 
-### Unbiased Guidance
-Education, analysis, and candid advice without pressure to buy.
+### Clear Guidance
+Plain explanations, candid advice, and no pressure to buy.
 
 ### Evidence Before Commitment
 We investigate properties, markets, alternatives, and meaningful unknowns before decisions harden.
@@ -35,10 +35,10 @@ We investigate properties, markets, alternatives, and meaningful unknowns before
 Price matters, but so do terms, timing, risk, protection, lifestyle, opportunity cost, and your future plans.
 
 ### Fiduciary Loyalty
-Your interests come first through loyalty, disclosure, reasonable care, confidentiality, and clear advocacy.
+**Fiduciary** means we are legally required to put your interests first when we represent you.
 
-### Meaningful Agency
-The choice remains yours. Our work should make you more capable of choosing — not more dependent on someone else choosing for you.
+### Your Choice Stays Yours
+Our work should make you more capable of choosing — not more dependent on someone else choosing for you.
 
 ---
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -4,13 +4,13 @@ title = "HomeBuyer Experts | Exclusive Buyer Representation"
 theme = "hbe"
 
 [params]
-  description = "Exclusive buyer representation for Northeast Ohio using VALUE — human-centered homebuying decision support built around values, alternatives, learning, uncertainty, and evidence."
-  tagline = "Price tells you what a home costs. VALUE helps you decide what that cost means to you."
+  description = "HomeBuyer Experts works only for home buyers in Northeast Ohio, helping people understand their options, protect their interests, and make better homebuying decisions."
+  tagline = "We work only for home buyers — never for the seller."
   phone = "(330) 328-3170"
   email = "cwhitehead@hbexperts.com"
   location = "Northeast Ohio"
   counties = "Summit, Stark, Medina, Wayne & Cuyahoga Counties"
-  informationLastUpdated = "August 27, 2026"
+  informationLastUpdated = "September 1, 2026"
 
 [menu]
   [[menu.main]]
@@ -26,11 +26,11 @@ theme = "hbe"
     url = "/value/"
     weight = 3
   [[menu.main]]
-    name = "Your Strategy Session"
+    name = "Strategy Session"
     url = "/strategy-session/"
     weight = 4
   [[menu.main]]
-    name = "Buyer Journey"
+    name = "Explore the Journey"
     url = "https://buyer.hbexperts.com/"
     weight = 5
   [[menu.main]]

--- a/secure-platform/src/issue33-production-worker.js
+++ b/secure-platform/src/issue33-production-worker.js
@@ -31,15 +31,15 @@ export const BUYER_FIRST_JS = `<script id="buyer-first-review-script">
   function openReview(){
     const rows=values();
     list.innerHTML=rows.length?rows.map(row=>'<div class="buyer-review-item"><small>'+escapeHtml(row.label)+'</small><div>'+escapeHtml(row.value)+'</div></div>').join(''):'<p class="buyer-review-empty">You have not entered any optional answers.</p>';
-    backdrop.classList.add('open'); document.body.style.overflow='hidden'; send.focus();
+    backdrop.classList.add('open'); backdrop.setAttribute('aria-hidden','false'); document.body.style.overflow='hidden'; send.focus();
   }
-  function closeReview(){backdrop.classList.remove('open');document.body.style.overflow='';reviewButton.focus();}
-  function escapeHtml(v){return String(v).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));}
+  function closeReview(){backdrop.classList.remove('open');backdrop.setAttribute('aria-hidden','true');document.body.style.overflow='';reviewButton.focus();}
+  function escapeHtml(v){return String(v).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot',"'":'&#39;'}[c]));}
   reviewButton.addEventListener('click',()=>{if(form.reportValidity())openReview();});
   edit.addEventListener('click',closeReview);
   backdrop.addEventListener('click',e=>{if(e.target===backdrop)closeReview();});
   document.addEventListener('keydown',e=>{if(e.key==='Escape'&&backdrop.classList.contains('open'))closeReview();});
-  send.addEventListener('click',()=>{approved=true;backdrop.classList.remove('open');document.body.style.overflow='';form.requestSubmit();});
+  send.addEventListener('click',()=>{approved=true;backdrop.classList.remove('open');backdrop.setAttribute('aria-hidden','true');document.body.style.overflow='';form.requestSubmit();});
   form.addEventListener('submit',e=>{if(!approved){e.preventDefault();openReview();}});
 })();
 </script>`;
@@ -58,7 +58,7 @@ export function addBuyerFirstClarity(text, pathname) {
       `<div class="submitbox"><strong>Nothing has been sent yet.</strong><p>Review exactly what HomeBuyer Experts will receive before you choose to send it.</p><button class="btn primary" id="review-before-send" type="button">Review before sending</button></div>`
     );
     if (!text.includes('id="buyer-review-backdrop"')) {
-      const review = `<div class="buyer-review-backdrop" id="buyer-review-backdrop" aria-hidden="false"><section class="buyer-review" role="dialog" aria-modal="true" aria-labelledby="buyer-review-title"><div class="eyebrow">BEFORE YOU SEND THIS</div><h2 id="buyer-review-title">Here is what HBE will receive.</h2><p class="buyer-review-intro">Read it over. You can go back and change anything before sending.</p><div class="buyer-review-list" id="buyer-review-list"></div><div class="buyer-review-trust"><strong>Sending this does not hire HBE, sign an agency agreement, or obligate you to buy a home.</strong><br>It creates your private buyer record so HomeBuyer Experts can review what you chose to share and follow up for a real conversation.</div><div class="buyer-review-actions"><button class="buyer-review-edit" id="buyer-review-edit" type="button">Back and edit</button><button class="buyer-review-send" id="buyer-review-send" type="button">Send to HomeBuyer Experts</button></div></section></div>`;
+      const review = `<div class="buyer-review-backdrop" id="buyer-review-backdrop" aria-hidden="true"><section class="buyer-review" role="dialog" aria-modal="true" aria-labelledby="buyer-review-title"><div class="eyebrow">BEFORE YOU SEND THIS</div><h2 id="buyer-review-title">Here is what HBE will receive.</h2><p class="buyer-review-intro">Read it over. You can go back and change anything before sending.</p><div class="buyer-review-list" id="buyer-review-list"></div><div class="buyer-review-trust"><strong>Sending this does not hire HBE, sign an agency agreement, or obligate you to buy a home.</strong><br>It creates your private buyer record so HomeBuyer Experts can review what you chose to share and follow up for a real conversation.</div><div class="buyer-review-actions"><button class="buyer-review-edit" id="buyer-review-edit" type="button">Back and edit</button><button class="buyer-review-send" id="buyer-review-send" type="button">Send to HomeBuyer Experts</button></div></section></div>`;
       text = text.replace('</body>', `${review}${BUYER_FIRST_JS}</body>`);
     }
   }

--- a/secure-platform/src/issue33-production-worker.js
+++ b/secure-platform/src/issue33-production-worker.js
@@ -34,7 +34,7 @@ export const BUYER_FIRST_JS = `<script id="buyer-first-review-script">
     backdrop.classList.add('open'); backdrop.setAttribute('aria-hidden','false'); document.body.style.overflow='hidden'; send.focus();
   }
   function closeReview(){backdrop.classList.remove('open');backdrop.setAttribute('aria-hidden','true');document.body.style.overflow='';reviewButton.focus();}
-  function escapeHtml(v){return String(v).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot',"'":'&#39;'}[c]));}
+  function escapeHtml(v){return String(v).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));}
   reviewButton.addEventListener('click',()=>{if(form.reportValidity())openReview();});
   edit.addEventListener('click',closeReview);
   backdrop.addEventListener('click',e=>{if(e.target===backdrop)closeReview();});

--- a/secure-platform/src/issue33-production-worker.js
+++ b/secure-platform/src/issue33-production-worker.js
@@ -3,6 +3,70 @@ import { STAGES } from './journey-stages.js';
 import { mutationCsrfToken } from './household-state.js';
 import { BIMATRIX_CSS, buyerBimatrixPanel, handleBuyerBimatrixRefresh } from './bimatrix/freshness.js';
 
+export const BUYER_FIRST_CSS = `<style id="buyer-first-clarity">
+.buyer-first-core{max-width:900px;margin:1rem auto;padding:1rem 1.1rem;border:1px solid #dfe8e2;border-left:4px solid #2d5a3d;border-radius:10px;background:#f7faf8;color:#2c2c2c;line-height:1.55}.buyer-first-core strong{color:#1a1a2e}.buyer-review-backdrop{position:fixed;inset:0;z-index:1000;background:rgba(26,26,46,.58);display:none;align-items:center;justify-content:center;padding:1rem}.buyer-review-backdrop.open{display:flex}.buyer-review{width:min(760px,100%);max-height:min(88vh,900px);overflow:auto;background:#fff;border-radius:14px;padding:1.35rem;box-shadow:0 24px 70px rgba(0,0,0,.28)}.buyer-review h2{margin:.15rem 0 .4rem;color:#1a1a2e;font-family:Georgia,serif}.buyer-review-intro{color:#555;margin:0 0 1rem}.buyer-review-list{display:grid;gap:.7rem;margin:1rem 0}.buyer-review-item{padding:.8rem .9rem;border:1px solid #e8e5e0;border-radius:9px;background:#faf9f6}.buyer-review-item small{display:block;color:#6b6b6b;font-weight:800;text-transform:uppercase;letter-spacing:.04em}.buyer-review-item div{white-space:pre-wrap}.buyer-review-trust{padding:1rem;border-radius:9px;background:#f7faf8;border:1px solid #dfe8e2;color:#333}.buyer-review-actions{display:flex;gap:.7rem;justify-content:flex-end;flex-wrap:wrap;margin-top:1rem}.buyer-review-actions button{font:inherit;font-weight:800;border-radius:7px;padding:.75rem 1rem;cursor:pointer}.buyer-review-edit{background:#fff;color:#2d5a3d;border:1px solid #2d5a3d}.buyer-review-send{background:#2d5a3d;color:#fff;border:1px solid #2d5a3d}.buyer-review-empty{color:#6b6b6b;font-style:italic}@media(max-width:600px){.buyer-review{padding:1rem}.buyer-review-actions{display:grid;grid-template-columns:1fr}.buyer-review-actions button{width:100%}}
+</style>`;
+
+export const BUYER_FIRST_JS = `<script id="buyer-first-review-script">
+(()=>{
+  const form=document.getElementById('buyerExperienceForm');
+  const reviewButton=document.getElementById('review-before-send');
+  const backdrop=document.getElementById('buyer-review-backdrop');
+  const list=document.getElementById('buyer-review-list');
+  const edit=document.getElementById('buyer-review-edit');
+  const send=document.getElementById('buyer-review-send');
+  if(!form||!reviewButton||!backdrop||!list||!edit||!send)return;
+  let approved=false;
+  const labels={first_name:'First name',last_name:'Last name',email:'Email',phone:'Phone',has_other_buyer:'Another buyer is part of this decision',why:'Why you are considering a home',situation:'Where you are starting',success_definition:'What a successful decision looks like',priorities:'Top priorities',non_negotiables:'Non-negotiables',decision_style:'Decision style',info_preference:'Information preference',uncertainty_style:'How you handle uncertainty',offer_pressure:'Offer pressure',head_heart:'Head / heart balance',disagreement_style:'How you handle disagreement',advisor_preference:'Advisor preference',past_experience:'Past buying experience',past_experience_detail:'Past experience detail',home_feeling:'How home should feel',lifestyle_pace:'Lifestyle pace',space_priority:'Space priority',timeline:'Timing',location:'Location',financing:'Financing',concerns:'Concerns',unknowns:'What you want to understand better',saturday_morning_vision:'Your picture of home',consultation_success:'What would make the consultation useful',notes:'Anything else for HBE',remember_device:'Remember this device',household_join_consent:'Join shared buyer case'};
+  const hidden=new Set(['household_invite_token']);
+  function values(){
+    const fd=new FormData(form), grouped=new Map();
+    for(const [key,value] of fd.entries()){
+      if(hidden.has(key))continue;
+      const v=String(value||'').trim(); if(!v)continue;
+      if(!grouped.has(key))grouped.set(key,[]); grouped.get(key).push(v);
+    }
+    return [...grouped.entries()].map(([key,vals])=>({label:labels[key]||key.replaceAll('_',' '),value:vals.join(', ')}));
+  }
+  function openReview(){
+    const rows=values();
+    list.innerHTML=rows.length?rows.map(row=>'<div class="buyer-review-item"><small>'+escapeHtml(row.label)+'</small><div>'+escapeHtml(row.value)+'</div></div>').join(''):'<p class="buyer-review-empty">You have not entered any optional answers.</p>';
+    backdrop.classList.add('open'); document.body.style.overflow='hidden'; send.focus();
+  }
+  function closeReview(){backdrop.classList.remove('open');document.body.style.overflow='';reviewButton.focus();}
+  function escapeHtml(v){return String(v).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));}
+  reviewButton.addEventListener('click',()=>{if(form.reportValidity())openReview();});
+  edit.addEventListener('click',closeReview);
+  backdrop.addEventListener('click',e=>{if(e.target===backdrop)closeReview();});
+  document.addEventListener('keydown',e=>{if(e.key==='Escape'&&backdrop.classList.contains('open'))closeReview();});
+  send.addEventListener('click',()=>{approved=true;backdrop.classList.remove('open');document.body.style.overflow='';form.requestSubmit();});
+  form.addEventListener('submit',e=>{if(!approved){e.preventDefault();openReview();}});
+})();
+</script>`;
+
+export function addBuyerFirstClarity(text, pathname) {
+  if (pathname === '/' || pathname === '/questionnaire') {
+    const core = `<div class="buyer-first-core" role="note"><strong>HomeBuyer Experts helps people buy homes.</strong> We work only for home buyers — never for the seller. Our job is to help you make the best choice for you, even when the best choice is to walk away.</div>`;
+    if (!text.includes('class="buyer-first-core"')) {
+      text = text.includes('<main') ? text.replace(/(<main[^>]*>)/, `$1${core}`) : text.replace('<body>', `<body>${core}`);
+    }
+  }
+
+  if (pathname === '/questionnaire' && text.includes('id="buyerExperienceForm"')) {
+    text = text.replace(
+      /<div class="submitbox"><strong>This is the moment HBE receives your information\.<\/strong><p>[\s\S]*?<button class="btn primary" type="submit">Submit to HBE<\/button><\/div>/,
+      `<div class="submitbox"><strong>Nothing has been sent yet.</strong><p>Review exactly what HomeBuyer Experts will receive before you choose to send it.</p><button class="btn primary" id="review-before-send" type="button">Review before sending</button></div>`
+    );
+    if (!text.includes('id="buyer-review-backdrop"')) {
+      const review = `<div class="buyer-review-backdrop" id="buyer-review-backdrop" aria-hidden="false"><section class="buyer-review" role="dialog" aria-modal="true" aria-labelledby="buyer-review-title"><div class="eyebrow">BEFORE YOU SEND THIS</div><h2 id="buyer-review-title">Here is what HBE will receive.</h2><p class="buyer-review-intro">Read it over. You can go back and change anything before sending.</p><div class="buyer-review-list" id="buyer-review-list"></div><div class="buyer-review-trust"><strong>Sending this does not hire HBE, sign an agency agreement, or obligate you to buy a home.</strong><br>It creates your private buyer record so HomeBuyer Experts can review what you chose to share and follow up for a real conversation.</div><div class="buyer-review-actions"><button class="buyer-review-edit" id="buyer-review-edit" type="button">Back and edit</button><button class="buyer-review-send" id="buyer-review-send" type="button">Send to HomeBuyer Experts</button></div></section></div>`;
+      text = text.replace('</body>', `${review}${BUYER_FIRST_JS}</body>`);
+    }
+  }
+
+  if (!text.includes('id="buyer-first-clarity"')) text = text.replace('</head>', `${BUYER_FIRST_CSS}</head>`);
+  return text;
+}
+
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
@@ -15,9 +79,6 @@ export default {
     const headers = new Headers(response.headers);
     const type = headers.get('content-type') || '';
 
-    // The base health endpoint is JSON, but some wrappers/provider responses may
-    // not preserve an application/json Content-Type. Health verification should
-    // depend on the route and parseable body, not on that optional header detail.
     if (request.method === 'GET' && url.pathname === '/health') {
       try {
         const body = await response.clone().json();
@@ -27,6 +88,7 @@ export default {
           persistence: 'd1-household-state'
         };
         body.issue33 = { bimatrix: true, buyer_refresh: true, canonical_review: 'monthly' };
+        body.issue36 = { buyer_first_clarity: true, pre_submit_review: true };
         headers.set('content-type', 'application/json; charset=utf-8');
         return new Response(JSON.stringify(body), {
           status: response.status,
@@ -49,6 +111,10 @@ export default {
       if (panel && !text.includes('id="possible-assistance"')) {
         text = injectBeforeMainEnd(text, panel);
       }
+    }
+
+    if (request.method === 'GET' && response.status === 200) {
+      text = addBuyerFirstClarity(text, url.pathname);
     }
 
     if (!text.includes('id="issue33-bimatrix-css"')) {

--- a/secure-platform/tests/issue36.test.mjs
+++ b/secure-platform/tests/issue36.test.mjs
@@ -35,9 +35,10 @@ test('review UI does not expose invitation token values', () => {
   assert.match(html, /hidden=new Set\(\['household_invite_token'\]\)/);
 });
 
-test('public journey gets buyer-only explanation without submission UI', () => {
+test('public journey gets buyer-only explanation without submission dialog markup', () => {
   const home = '<!doctype html><html><head></head><body><main><h1>Journey</h1></main></body></html>';
   const html = addBuyerFirstClarity(home, '/');
   assert.match(html, /helps people buy homes/i);
-  assert.doesNotMatch(html, /buyer-review-backdrop/);
+  assert.doesNotMatch(html, /id="buyer-review-backdrop"/);
+  assert.doesNotMatch(html, /id="buyer-first-review-script"/);
 });

--- a/secure-platform/tests/issue36.test.mjs
+++ b/secure-platform/tests/issue36.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { addBuyerFirstClarity } from '../src/issue33-production-worker.js';
+
+const questionnaire = `<!doctype html><html><head></head><body><main><form id="buyerExperienceForm" method="post" action="/api/intake" novalidate><input name="first_name" required><input name="last_name" required><input type="email" name="email" required><div class="submitbox"><strong>This is the moment HBE receives your information.</strong><p>Submitting creates your private buyer record and alerts HBE that your Buyer Experience is ready for review. HBE will store what you actually submitted; unanswered reflective questions remain unanswered.</p><button class="btn primary" type="submit">Submit to HBE</button></div></form></main></body></html>`;
+
+test('questionnaire adds plain-English buyer-only explanation', () => {
+  const html = addBuyerFirstClarity(questionnaire, '/questionnaire');
+  assert.match(html, /helps people buy homes/i);
+  assert.match(html, /only for home buyers/i);
+  assert.match(html, /never for the seller/i);
+  assert.match(html, /walk away/i);
+});
+
+test('questionnaire requires review before final submission', () => {
+  const html = addBuyerFirstClarity(questionnaire, '/questionnaire');
+  assert.match(html, /Review before sending/);
+  assert.match(html, /Here is what HBE will receive/);
+  assert.match(html, /Back and edit/);
+  assert.match(html, /Send to HomeBuyer Experts/);
+  assert.match(html, /does not hire HBE/i);
+  assert.match(html, /does not.*sign an agency agreement/i);
+  assert.match(html, /does not.*obligate you to buy/i);
+  assert.doesNotMatch(html, />Submit to HBE<\/button>/);
+});
+
+test('pre-submit review preserves the existing intake action', () => {
+  const html = addBuyerFirstClarity(questionnaire, '/questionnaire');
+  assert.match(html, /action="\/api\/intake"/);
+  assert.match(html, /form\.requestSubmit\(\)/);
+});
+
+test('review UI does not expose invitation token values', () => {
+  const html = addBuyerFirstClarity(questionnaire, '/questionnaire');
+  assert.match(html, /hidden=new Set\(\['household_invite_token'\]\)/);
+});
+
+test('public journey gets buyer-only explanation without submission UI', () => {
+  const home = '<!doctype html><html><head></head><body><main><h1>Journey</h1></main></body></html>';
+  const html = addBuyerFirstClarity(home, '/');
+  assert.match(html, /helps people buy homes/i);
+  assert.doesNotMatch(html, /buyer-review-backdrop/);
+});

--- a/themes/hbe/layouts/partials/header.html
+++ b/themes/hbe/layouts/partials/header.html
@@ -11,7 +11,7 @@
       <li><a href="{{ .URL | relURL }}"{{ if $.IsMenuCurrent "main" . }} class="active"{{ end }}>{{ .Name }}</a></li>
       {{ end }}
       <li><a href="https://buyer.hbexperts.com/hbe">HBE Login</a></li>
-      <li class="nav-cta"><a href="{{ "strategy-session/" | relURL }}" style="white-space: nowrap;">Schedule Consultation</a></li>
+      <li class="nav-cta"><a href="https://buyer.hbexperts.com/questionnaire" style="white-space: nowrap;">Start Buyer Experience</a></li>
     </ul>
   </nav>
 </header>


### PR DESCRIPTION
Implements the first coherent slice of Issue #36.

## What changes
- Leads the public site with plain-English buyer-only positioning.
- Makes **Start Buyer Experience** the clear header action.
- Clarifies the Journey navigation label.
- Adds a plain explanation to the public Buyer Journey and Buyer Experience: HBE works only for buyers, never sellers, and may recommend walking away.
- Replaces the immediate final submit button with **Review before sending**.
- Shows the buyer exactly what HBE will receive, with **Back and edit** and a deliberate **Send to HomeBuyer Experts** action.
- States plainly that sending does not hire HBE, sign an agency agreement, or obligate the buyer to purchase.
- Preserves the existing `/api/intake` backend, invitation flow, D1 behavior, session model, and security boundaries.
- Adds focused tests and a dedicated secure-platform CI workflow for this slice.

## Truth check
The current repository no longer contains the previously suspected public `4–5 minute` Buyer Experience promise. The Strategy Session page truthfully describes the session itself as approximately one hour, so this PR does not invent a replacement duration estimate.

## Security / privacy
- No buyer data is added to public GitHub Pages.
- Pre-submit review is client-side presentation only; backend persistence remains unchanged.
- Invitation tokens are intentionally excluded from the human-readable review summary.
- Existing explicit co-buyer consent remains in force.

## North Star
What is best for the buyer?

Refs #36