### PR TITLE
Clean up public HBE buyer experience before traffic

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,6 +1,6 @@
 ---
 title: "Experience Matters When the Decision Matters"
-subtitle: "For more than 20 years, HomeBuyer Experts has focused on one question: what is best for the buyer?"
+subtitle: "Serving buyers since 2004, HomeBuyer Experts has focused on one question: what is best for the buyer?"
 description: "Meet HomeBuyer Experts — an exclusive buyer brokerage using VALUE, a human-centered decision-support system, to help Northeast Ohio buyers understand consequential housing decisions and choose wisely."
 ---
 
@@ -42,7 +42,7 @@ VALUE does not tell buyers what to choose. It helps make the choice easier to un
 
 ### A buyer advocate, not just a real estate professional.
 
-For over two decades, Christopher has dedicated his career to helping buyers navigate complex real estate decisions.
+Christopher has served home buyers since 2004, helping people navigate complex real estate decisions.
 
 His background combines:
 

--- a/content/buyer-value-agreement.md
+++ b/content/buyer-value-agreement.md
@@ -1,7 +1,7 @@
 ---
 title: "The Buyer Value Agreement"
 subtitle: "A commitment to your interests — not a contract designed to move a transaction forward."
-description: "Understand HBE's Buyer Value Agreement: representation, the current 2.75% pilot compensation model, conflicts, incentives, and how VALUE keeps the relationship centered on the buyer's decision."
+description: "Understand HBE's Buyer Value Agreement: representation, negotiable compensation, conflicts, incentives, and how VALUE keeps the relationship centered on the buyer's decision."
 ---
 
 ## What Is the Buyer Value Agreement?
@@ -49,15 +49,15 @@ You deserve to understand who is in your corner, what they are paid, and what in
 
 ---
 
-## The Current Compensation Pilot
+## How Compensation Is Handled
 
-HBE is currently piloting a **2.75% buyer-broker compensation structure** while measuring the actual professional time and resources required to serve buyers from strategy through closing.
+Real-estate compensation is negotiable.
 
-The purpose of the pilot is not to declare that percentage compensation is the permanent answer. It gives HBE a stable, professional compensation structure while we collect real evidence about workload, travel, showings, research, decision support, negotiation, diligence, and brokerage support.
+Before you hire HBE, we explain how HBE would be compensated, what sources of compensation may be available in the transaction, and any material incentives that could affect the relationship. The compensation terms that apply to your representation are stated in your written agreement — not published as a one-size-fits-all public rate card.
 
-Internally, HBE is comparing the pilot against alternative models so a future structure can be designed from actual buyer-service data rather than industry habit alone.
+Seller- or builder-paid compensation is not automatic and does not change HBE's duty to put the buyer's interests first.
 
-The amount and sources of compensation applicable to your representation are stated in your signed agreement. Real-estate compensation is negotiable.
+The purpose of discussing compensation early is simple: you should understand the economics of the relationship before those economics can influence a consequential decision.
 
 ---
 

--- a/content/conflict-register.md
+++ b/content/conflict-register.md
@@ -64,8 +64,6 @@ We continually evaluate our compensation structure against a harder question:
 
 > **Would we still recommend this if HBE earned exactly the same amount whether the buyer proceeded, renegotiated, waited, chose another home, or walked away?**
 
-During the current pilot, HBE is also tracking actual professional time and comparing alternative compensation structures internally so future compensation can be designed from evidence rather than tradition alone.
-
 ---
 
 ## Seller or Builder Incentives

--- a/content/contact.md
+++ b/content/contact.md
@@ -8,11 +8,11 @@ description: "Contact HomeBuyer Experts for buyer-first guidance and exclusive b
 
 **Phone:** [(330) 328-3170](tel:3303283170)
 
-**Email:** [cwhitehead@hbexperts.com](mailto:cwhitehead@hbexperts.com)
+**Email:** [buyers@hbexperts.com](mailto:buyers@hbexperts.com)
 
 **Serving:** Summit, Stark, Medina, Wayne & Cuyahoga Counties
 
-Every message is read personally by Chris or Jen. You can expect a response within **12 business hours**.
+Every buyer message is reviewed by HomeBuyer Experts.
 
 ---
 
@@ -56,6 +56,6 @@ And one practical test:
 
 If the answer is to proceed, we help you proceed well. If the answer is to pause, change direction, or walk away, that is part of good representation too.
 
-**Email:** [cwhitehead@hbexperts.com](mailto:cwhitehead@hbexperts.com)
+**Email:** [buyers@hbexperts.com](mailto:buyers@hbexperts.com)
 
 **Phone:** [(330) 328-3170](tel:3303283170)

--- a/content/strategy-session.md
+++ b/content/strategy-session.md
@@ -107,7 +107,9 @@ This is **not** a sales call and **not** a meeting designed to move you toward s
 
 It is a conversation designed to increase your understanding and agency before the transaction begins exerting its own momentum.
 
-During the session, we can explain exclusive buyer representation and the **buyer-agency agreement** — what representation means, how compensation works, and what each party is committing to.
+During the session, we can explain exclusive buyer representation and the **Buyer Value Agreement** — what representation means, how compensation works, how incentives are handled, and what each party is committing to.
+
+[Learn how the Buyer Value Agreement works →]({{< relref "buyer-value-agreement" >}})
 
 Nothing is signed merely because we had the conversation. You decide whether HBE is right for you and when you are ready to proceed.
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,10 +7,10 @@ theme = "hbe"
   description = "HomeBuyer Experts works only for home buyers in Northeast Ohio, helping people understand their options, protect their interests, and make better homebuying decisions."
   tagline = "We work only for home buyers — never for the seller."
   phone = "(330) 328-3170"
-  email = "cwhitehead@hbexperts.com"
+  email = "buyers@hbexperts.com"
   location = "Northeast Ohio"
   counties = "Summit, Stark, Medina, Wayne & Cuyahoga Counties"
-  informationLastUpdated = "September 1, 2026"
+  informationLastUpdated = "September 2, 2026"
 
 [menu]
   [[menu.main]]
@@ -34,13 +34,9 @@ theme = "hbe"
     url = "https://buyer.hbexperts.com/"
     weight = 5
   [[menu.main]]
-    name = "Conflict Register"
-    url = "/conflict-register/"
-    weight = 6
-  [[menu.main]]
     name = "Contact"
     url = "/contact/"
-    weight = 7
+    weight = 6
 
 [markup]
   [markup.goldmark]

--- a/themes/hbe/layouts/index.html
+++ b/themes/hbe/layouts/index.html
@@ -8,13 +8,12 @@
       <a href="{{ "value/" | relURL }}" class="btn btn-secondary">See How VALUE Works</a>
       <a href="https://buyer.hbexperts.com/" class="btn btn-primary">Explore the Buyer Journey</a>
     </div>
-    <p style="margin-top:1rem;font-size:.9rem;">HBE professional? <a href="https://buyer.hbexperts.com/hbe" style="font-weight:600;">Sign in to HBEUI</a></p>
   </div>
 </section>
 
 <div class="trust-bar">
   <div class="trust-bar-inner">
-    <div class="trust-item"><span class="icon">🏛</span> 20+ Years Experience</div>
+    <div class="trust-item"><span class="icon">🏛</span> Serving Buyers Since 2004</div>
     <div class="trust-item"><span class="icon">🤝</span> Exclusive Buyer Representation</div>
     <div class="trust-item"><span class="icon">📍</span> {{ .Site.Params.counties }}</div>
   </div>

--- a/themes/hbe/layouts/partials/footer.html
+++ b/themes/hbe/layouts/partials/footer.html
@@ -11,6 +11,7 @@
     </div>
     <div class="footer-links">
       <p>
+        <a href="{{ "conflict-register/" | relURL }}">Conflict Register</a> ·
         <a href="{{ "privacy/" | relURL }}">Privacy Policy</a> ·
         <a href="{{ "terms/" | relURL }}">Terms</a> ·
         <a href="{{ "accessibility/" | relURL }}">Accessibility</a> ·

--- a/themes/hbe/layouts/partials/header.html
+++ b/themes/hbe/layouts/partials/header.html
@@ -10,7 +10,6 @@
       {{ range .Site.Menus.main }}
       <li><a href="{{ .URL | relURL }}"{{ if $.IsMenuCurrent "main" . }} class="active"{{ end }}>{{ .Name }}</a></li>
       {{ end }}
-      <li><a href="https://buyer.hbexperts.com/hbe">HBE Login</a></li>
       <li class="nav-cta"><a href="https://buyer.hbexperts.com/questionnaire" style="white-space: nowrap;">Start Buyer Experience</a></li>
     </ul>
   </nav>


### PR DESCRIPTION
Implements the approved public-site cleanup order from private MavericksATeam Issue #49.

Changes:
- removes specific public compensation/rate-card language while preserving negotiability and transparency;
- removes staff-login advertising from consumer homepage/nav;
- changes credibility copy to `Serving Buyers Since 2004`;
- uses `buyers@hbexperts.com` as the public buyer contact while preserving broker contact on licensing pages;
- removes stale personal-reader/response-time promises from Contact;
- moves Conflict Register out of primary navigation and into the footer transparency links;
- makes the Buyer Value Agreement a subordinate step from the Strategy Session;
- removes internal compensation-pilot language from the public Conflict Register.

No changes to Buyer Worker authorization, D1 household isolation, CSRF, HBEUI Access, MLS boundaries, or sensitive-upload controls.

Sentinel review requested before merge/deploy.