### PR TITLE
Fix Buyer Experience guided-answer chips (concerns + timeline)

### DIFF
--- a/secure-platform/src/buyer-guidance.js
+++ b/secure-platform/src/buyer-guidance.js
@@ -1,0 +1,171 @@
+export const TIMELINE_CHIP_VALUES = [
+  'Immediately / within 30 days',
+  '1–3 months',
+  '3–6 months',
+  '6–12 months',
+  'More than a year',
+  'Just exploring / unsure'
+];
+
+export const CONCERN_CHIP_VALUES = [
+  'Paying too much',
+  'Choosing the wrong area',
+  'Hidden property problems',
+  'Financing / monthly cost',
+  'Negotiating effectively',
+  'Timing / market conditions',
+  'Inspection issues',
+  'Making the wrong decision',
+  'I do not know what I do not know'
+];
+
+export const BUYER_GUIDANCE = {
+  why: {
+    help: 'A sentence or two is enough. Think about what is changing, what you want more of, or what is pushing the idea forward.',
+    suggestions: ['Need more space', 'Want a different location', 'Life or family change', 'Rent no longer feels right', 'Just exploring', 'I’m not sure yet']
+  },
+  timeline: {
+    help: 'This can be approximate. There is no penalty for not having a timeline yet.',
+    suggestions: TIMELINE_CHIP_VALUES
+  },
+  location: {
+    help: 'You can name a city, commute, school area, neighborhood feel, or simply say you are still open.',
+    suggestions: ['Near work', 'Near family', 'Akron area', 'Open to several areas', 'Commute matters most', 'I’m not sure yet']
+  },
+  concerns: {
+    help: 'Anything that makes you hesitate belongs here. You do not need to know the real-estate vocabulary.',
+    suggestions: CONCERN_CHIP_VALUES
+  },
+  notes: {
+    help: 'Optional. Use this only if there is something you want a human at HBE to understand before talking with you.',
+    suggestions: ['Nothing else right now', 'I’d rather discuss this live', 'I’m still figuring things out']
+  }
+};
+
+/**
+ * Self-contained injector for the Buyer Experience form.
+ * Safe to Function.prototype.toString() into the page script: no outer-scope references.
+ */
+export function installBuyerGuidance(form, doc, guide) {
+  if (!form || !doc) return;
+
+  function isElement(node) {
+    return !!(node && node.nodeType === 1);
+  }
+
+  function firstControl(named) {
+    if (!named) return null;
+    if (isElement(named)) return named;
+    if (typeof named.length === 'number') {
+      const node = named[0] || (typeof named.item === 'function' ? named.item(0) : null);
+      return isElement(node) ? node : node || null;
+    }
+    return named;
+  }
+
+  function allControls(named) {
+    if (!named) return [];
+    if (isElement(named)) return [named];
+    if (typeof named.length === 'number') {
+      const out = [];
+      for (let i = 0; i < named.length; i++) {
+        const node = named[i] || (typeof named.item === 'function' ? named.item(i) : null);
+        if (node) out.push(node);
+      }
+      return out;
+    }
+    return [named];
+  }
+
+  function fieldKind(el) {
+    const type = String((el && el.type) || '').toLowerCase();
+    const tag = String((el && el.tagName) || '').toUpperCase();
+    if (type === 'checkbox') return 'checkbox';
+    if (type === 'radio') return 'radio';
+    if (tag === 'SELECT' || type === 'select-one' || type === 'select-multiple') return 'select';
+    return 'text';
+  }
+
+  function insertAnchor(name, first) {
+    const kind = fieldKind(first);
+    if (kind === 'checkbox' || kind === 'radio') {
+      if (name === 'concerns' && typeof form.querySelector === 'function') {
+        const box = form.querySelector('#concernChoices');
+        if (box) return box;
+      }
+      if (typeof first.closest === 'function') {
+        const group = first.closest('#concernChoices, .choices, .group');
+        if (group) return group;
+      }
+    }
+    return first;
+  }
+
+  function applySuggestion(name, suggestion) {
+    const named = form.elements.namedItem(name);
+    const first = firstControl(named);
+    if (!first) return;
+    const kind = fieldKind(first);
+    if (kind === 'checkbox' || kind === 'radio') {
+      const match = allControls(named).find(function (el) { return el.value === suggestion; });
+      if (!match) return;
+      if (kind === 'checkbox') match.checked = !match.checked;
+      else match.checked = true;
+      match.dispatchEvent(new Event('input', { bubbles: true }));
+      match.dispatchEvent(new Event('change', { bubbles: true }));
+      if (typeof match.focus === 'function') match.focus();
+      return;
+    }
+    first.value = suggestion;
+    first.dispatchEvent(new Event('input', { bubbles: true }));
+    if (kind === 'select') first.dispatchEvent(new Event('change', { bubbles: true }));
+    if (typeof first.focus === 'function') first.focus();
+  }
+
+  const entries = Object.entries(guide);
+  for (let i = 0; i < entries.length; i++) {
+    const name = entries[i][0];
+    const cfg = entries[i][1];
+    try {
+      const named = form.elements.namedItem(name);
+      const first = firstControl(named);
+      if (!first) continue;
+      if (!first.dataset) continue;
+      if (first.dataset.guided === 'yes') continue;
+      first.dataset.guided = 'yes';
+      const anchor = insertAnchor(name, first);
+      if (!anchor || typeof anchor.insertAdjacentElement !== 'function') continue;
+      const help = doc.createElement('small');
+      help.className = 'buyer-answer-help';
+      help.innerHTML = '<strong>Need a starting point?</strong> ' + cfg.help + ' It is okay not to know yet.';
+      const chips = doc.createElement('div');
+      chips.className = 'buyer-suggestions';
+      chips.setAttribute('aria-label', 'Answer suggestions');
+      const suggestions = cfg.suggestions || [];
+      for (let s = 0; s < suggestions.length; s++) {
+        const suggestion = suggestions[s];
+        const button = doc.createElement('button');
+        button.type = 'button';
+        button.className = 'buyer-suggestion';
+        button.textContent = suggestion;
+        button.addEventListener('click', function () { applySuggestion(name, suggestion); });
+        chips.appendChild(button);
+      }
+      anchor.insertAdjacentElement('afterend', chips);
+      anchor.insertAdjacentElement('afterend', help);
+    } catch (_err) {
+      /* A throw/mismatch on one field must not abort remaining fields. */
+    }
+  }
+}
+
+export function buyerGuidanceRuntimeScript() {
+  const guide = '{' + Object.entries(BUYER_GUIDANCE).map(([name, cfg]) => (
+    name + ':{help:' + JSON.stringify(cfg.help) + ',suggestions:' + JSON.stringify(cfg.suggestions) + '}'
+  )).join(',') + '}';
+  return '(()=>{\n' +
+    '  const form=document.getElementById(\'buyerExperienceForm\'); if(!form)return;\n' +
+    '  const guide=' + guide + ';\n' +
+    '  (' + installBuyerGuidance.toString() + ')(form,document,guide);\n' +
+    '})();';
+}

--- a/secure-platform/src/issue33-production-worker.js
+++ b/secure-platform/src/issue33-production-worker.js
@@ -2,6 +2,7 @@ import appWorker from './issue29-production-worker.js';
 import { STAGES } from './journey-stages.js';
 import { mutationCsrfToken } from './household-state.js';
 import { BIMATRIX_CSS, buyerBimatrixPanel, handleBuyerBimatrixRefresh } from './bimatrix/freshness.js';
+import { buyerGuidanceRuntimeScript } from './buyer-guidance.js';
 
 export const BUYER_FIRST_CSS = `<style id="buyer-first-clarity">
 .buyer-first-core{max-width:900px;margin:1rem auto;padding:1rem 1.1rem;border:1px solid #dfe8e2;border-left:4px solid #2d5a3d;border-radius:10px;background:#f7faf8;color:#2c2c2c;line-height:1.55}.buyer-first-core strong{color:#1a1a2e}.buyer-review-backdrop{position:fixed;inset:0;z-index:1000;background:rgba(26,26,46,.58);display:none;align-items:center;justify-content:center;padding:1rem}.buyer-review-backdrop.open{display:flex}.buyer-review{width:min(760px,100%);max-height:min(88vh,900px);overflow:auto;background:#fff;border-radius:14px;padding:1.35rem;box-shadow:0 24px 70px rgba(0,0,0,.28)}.buyer-review h2{margin:.15rem 0 .4rem;color:#1a1a2e;font-family:Georgia,serif}.buyer-review-intro{color:#555;margin:0 0 1rem}.buyer-review-list{display:grid;gap:.7rem;margin:1rem 0}.buyer-review-item{padding:.8rem .9rem;border:1px solid #e8e5e0;border-radius:9px;background:#faf9f6}.buyer-review-item small{display:block;color:#6b6b6b;font-weight:800;text-transform:uppercase;letter-spacing:.04em}.buyer-review-item div{white-space:pre-wrap}.buyer-review-trust{padding:1rem;border-radius:9px;background:#f7faf8;border:1px solid #dfe8e2;color:#333}.buyer-review-actions{display:flex;gap:.7rem;justify-content:flex-end;flex-wrap:wrap;margin-top:1rem}.buyer-review-actions button{font:inherit;font-weight:800;border-radius:7px;padding:.75rem 1rem;cursor:pointer}.buyer-review-edit{background:#fff;color:#2d5a3d;border:1px solid #2d5a3d}.buyer-review-send{background:#2d5a3d;color:#fff;border:1px solid #2d5a3d}.buyer-review-empty{color:#6b6b6b;font-style:italic}
@@ -48,28 +49,7 @@ export const BUYER_FIRST_JS = `<script id="buyer-first-review-script">
 </script>`;
 
 export const BUYER_GUIDANCE_JS = `<script id="buyer-guided-answer-script">
-(()=>{
-  const form=document.getElementById('buyerExperienceForm'); if(!form)return;
-  const guide={
-    why:{help:'A sentence or two is enough. Think about what is changing, what you want more of, or what is pushing the idea forward.',suggestions:['Need more space','Want a different location','Life or family change','Rent no longer feels right','Just exploring','I’m not sure yet']},
-    timeline:{help:'This can be approximate. There is no penalty for not having a timeline yet.',suggestions:['As soon as it makes sense','Within 3–6 months','Later this year','Next year','No deadline','I’m not sure yet']},
-    location:{help:'You can name a city, commute, school area, neighborhood feel, or simply say you are still open.',suggestions:['Near work','Near family','Akron area','Open to several areas','Commute matters most','I’m not sure yet']},
-    concerns:{help:'Anything that makes you hesitate belongs here. You do not need to know the real-estate vocabulary.',suggestions:['Affordability','Choosing the wrong house','Hidden condition problems','Financing','Timing','I’m not sure what to worry about yet']},
-    notes:{help:'Optional. Use this only if there is something you want a human at HBE to understand before talking with you.',suggestions:['Nothing else right now','I’d rather discuss this live','I’m still figuring things out']}
-  };
-  for(const [name,cfg] of Object.entries(guide)){
-    const field=form.elements.namedItem(name); if(!field||field.dataset.guided==='yes')continue;
-    field.dataset.guided='yes';
-    const help=document.createElement('small'); help.className='buyer-answer-help'; help.innerHTML='<strong>Need a starting point?</strong> '+cfg.help+' It is okay not to know yet.';
-    const chips=document.createElement('div'); chips.className='buyer-suggestions'; chips.setAttribute('aria-label','Answer suggestions');
-    for(const suggestion of cfg.suggestions){
-      const button=document.createElement('button'); button.type='button'; button.className='buyer-suggestion'; button.textContent=suggestion;
-      button.addEventListener('click',()=>{field.value=suggestion; field.dispatchEvent(new Event('input',{bubbles:true})); field.focus();});
-      chips.appendChild(button);
-    }
-    field.insertAdjacentElement('afterend',chips); field.insertAdjacentElement('afterend',help);
-  }
-})();
+${buyerGuidanceRuntimeScript()}
 </script>`;
 
 export const BUYER_PORTAL_FOCUS_JS = `<script id="buyer-portal-focus-script">

--- a/secure-platform/tests/issue36.test.mjs
+++ b/secure-platform/tests/issue36.test.mjs
@@ -1,6 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { addBuyerFirstClarity } from '../src/issue33-production-worker.js';
+import { readFileSync } from 'node:fs';
+import { BUYER_GUIDANCE, TIMELINE_CHIP_VALUES, CONCERN_CHIP_VALUES, installBuyerGuidance } from '../src/buyer-guidance.js';
 
 const questionnaire = `<!doctype html><html><head></head><body><main><form id="buyerExperienceForm" method="post" action="/api/intake" novalidate><input name="first_name" required><input name="last_name" required><input type="email" name="email" required><textarea name="why"></textarea><input name="timeline"><input name="location"><textarea name="concerns"></textarea><textarea name="notes"></textarea><div class="submitbox"><strong>This is the moment HBE receives your information.</strong><p>Submitting creates your private buyer record and alerts HBE that your Buyer Experience is ready for review. HBE will store what you actually submitted; unanswered reflective questions remain unanswered.</p><button class="btn primary" type="submit">Submit to HBE</button></div></form></main></body></html>`;
 
@@ -68,4 +70,287 @@ test('buyer portal gets a focused Now Next Why Time layer while preserving expan
   assert.match(html, /Time/);
   assert.match(html, /See the full 17-stage journey/);
   assert.match(html, /Current-step checklist/);
+});
+function matches(el, selector) {
+  if (!el) return false;
+  return selector.split(',').map(s => s.trim()).some(sel => {
+    if (sel.startsWith('#')) return el.id === sel.slice(1);
+    if (sel.startsWith('.')) return String(el.className || '').split(/\s+/).includes(sel.slice(1));
+    return String(el.tagName || '').toLowerCase() === sel.toLowerCase();
+  });
+}
+
+function createEl(tag, attrs = {}) {
+  const el = {
+    nodeType: 1,
+    tagName: tag.toUpperCase(),
+    type: attrs.type || (tag === 'select' ? 'select-one' : tag === 'textarea' ? 'textarea' : tag === 'button' ? 'button' : 'text'),
+    name: attrs.name || '',
+    checked: !!attrs.checked,
+    dataset: Object.assign({}, attrs.dataset),
+    className: attrs.className || '',
+    id: attrs.id || '',
+    children: [],
+    parentNode: attrs.parentNode || null,
+    nextSiblings: [],
+    listeners: {},
+    options: attrs.options || [],
+    selectedIndex: attrs.selectedIndex ?? 0,
+    textContent: attrs.textContent || '',
+    innerHTML: '',
+    focused: false,
+    insertAdjacentElement(pos, node) {
+      if (pos !== 'afterend') throw new Error('unsupported position ' + pos);
+      this.nextSiblings.unshift(node);
+      node.parentNode = this.parentNode;
+      return node;
+    },
+    closest(sel) {
+      let n = this;
+      while (n) {
+        if (matches(n, sel)) return n;
+        n = n.parentNode;
+      }
+      return null;
+    },
+    querySelector(sel) {
+      const stack = [...(this.children || [])];
+      while (stack.length) {
+        const n = stack.shift();
+        if (matches(n, sel)) return n;
+        if (n.children) stack.push(...n.children);
+      }
+      return null;
+    },
+    setAttribute(k, v) {
+      this.attrs = this.attrs || {};
+      this.attrs[k] = v;
+    },
+    addEventListener(type, fn) {
+      this.listeners[type] = this.listeners[type] || [];
+      this.listeners[type].push(fn);
+    },
+    appendChild(c) {
+      this.children.push(c);
+      c.parentNode = this;
+      return c;
+    },
+    dispatchEvent(ev) {
+      (this.listeners[ev.type] || []).forEach(fn => fn(ev));
+      return true;
+    },
+    focus() { this.focused = true; },
+    click() { (this.listeners.click || []).forEach(fn => fn({ type: 'click' })); }
+  };
+  if (tag.toUpperCase() === 'SELECT') {
+    let selectedIndex = attrs.selectedIndex ?? 0;
+    Object.defineProperty(el, 'selectedIndex', {
+      get() { return selectedIndex; },
+      set(v) { selectedIndex = v; }
+    });
+    Object.defineProperty(el, 'value', {
+      get() {
+        const opt = this.options[selectedIndex];
+        if (!opt) return '';
+        return opt.value !== undefined ? opt.value : opt.text;
+      },
+      set(v) {
+        const idx = this.options.findIndex(o => (o.value !== undefined ? o.value : o.text) === v);
+        selectedIndex = idx;
+      }
+    });
+  } else {
+    el.value = attrs.value ?? '';
+  }
+  return el;
+}
+
+function radioNodeList(controls) {
+  const list = { length: controls.length, item(i) { return controls[i] || null; } };
+  controls.forEach((c, i) => { list[i] = c; });
+  return list;
+}
+
+function chipsAfter(el) {
+  return (el.nextSiblings || []).find(n => n.className === 'buyer-suggestions') || null;
+}
+
+function clickChip(el, label) {
+  const chips = chipsAfter(el);
+  assert.ok(chips, 'expected suggestion chips after field/group');
+  const btn = chips.children.find(b => b.textContent === label);
+  assert.ok(btn, 'expected chip labeled ' + label);
+  btn.click();
+  return btn;
+}
+
+function fakeDocument() {
+  return { createElement(tag) { return createEl(tag); } };
+}
+
+function portalLikeForm() {
+  const first_name = createEl('input', { name: 'first_name', type: 'text' });
+  const last_name = createEl('input', { name: 'last_name', type: 'text' });
+  const email = createEl('input', { name: 'email', type: 'email' });
+  const phone = createEl('input', { name: 'phone', type: 'tel' });
+  const why = createEl('textarea', { name: 'why' });
+  const location = createEl('input', { name: 'location', type: 'text' });
+  const notes = createEl('textarea', { name: 'notes' });
+  const timeline = createEl('select', { name: 'timeline' });
+  timeline.options = [
+    { value: '', text: 'Choose one if helpful' },
+    ...TIMELINE_CHIP_VALUES.map(v => ({ value: v, text: v }))
+  ];
+  timeline.selectedIndex = 0;
+
+  const concernChoices = createEl('div', { id: 'concernChoices', className: 'choices' });
+  const concernGroup = createEl('div', { className: 'group' });
+  concernChoices.parentNode = concernGroup;
+  concernGroup.children.push(concernChoices);
+  const boxes = CONCERN_CHIP_VALUES.map(label => {
+    const box = createEl('input', { type: 'checkbox', name: 'concerns', value: label });
+    box.parentNode = concernChoices;
+    concernChoices.children.push(box);
+    return box;
+  });
+
+  const fields = {
+    first_name, last_name, email, phone, why, location, notes, timeline,
+    concerns: radioNodeList(boxes)
+  };
+
+  const form = {
+    elements: { namedItem(name) { return fields[name] || null; } },
+    querySelector(sel) { return sel === '#concernChoices' ? concernChoices : null; },
+    fields, boxes, concernChoices
+  };
+  return form;
+}
+
+function workerLikeForm() {
+  const fields = {
+    first_name: createEl('input', { name: 'first_name' }),
+    email: createEl('input', { name: 'email', type: 'email' }),
+    why: createEl('textarea', { name: 'why' }),
+    timeline: createEl('input', { name: 'timeline', type: 'text' }),
+    location: createEl('input', { name: 'location', type: 'text' }),
+    concerns: createEl('textarea', { name: 'concerns' }),
+    notes: createEl('textarea', { name: 'notes' })
+  };
+  return {
+    elements: { namedItem(name) { return fields[name] || null; } },
+    querySelector() { return null; },
+    fields
+  };
+}
+
+test('guided chips use live timeline options and concern checkbox labels', () => {
+  const html = addBuyerFirstClarity(questionnaire, '/questionnaire');
+  for (const value of TIMELINE_CHIP_VALUES) assert.ok(html.includes(value), value);
+  for (const value of CONCERN_CHIP_VALUES) assert.ok(html.includes(value), value);
+  assert.equal(html.includes('As soon as it makes sense'), false);
+  assert.equal(html.includes('Within 3–6 months'), false);
+  assert.doesNotMatch(html, /phone:\{help:/);
+});
+
+test('injector does not throw on concerns checkbox group and still chips notes', () => {
+  const form = portalLikeForm();
+  const named = form.elements.namedItem('concerns');
+  assert.equal(named.nodeType, undefined);
+  assert.equal(named.dataset, undefined);
+  assert.equal(typeof named.length, 'number');
+  assert.doesNotThrow(() => installBuyerGuidance(form, fakeDocument(), BUYER_GUIDANCE));
+  assert.ok(chipsAfter(form.concernChoices), 'concerns group should have chips');
+  assert.equal(chipsAfter(form.concernChoices).children.length, CONCERN_CHIP_VALUES.length);
+  assert.ok(chipsAfter(form.fields.notes), 'notes must still receive chips after concerns');
+  assert.ok(chipsAfter(form.fields.timeline), 'timeline should have chips');
+  assert.ok(chipsAfter(form.fields.why), 'why should have chips');
+  assert.ok(chipsAfter(form.fields.location), 'location should have chips');
+});
+
+test('timeline chips match the six option values and set a real selected option', () => {
+  const form = portalLikeForm();
+  installBuyerGuidance(form, fakeDocument(), BUYER_GUIDANCE);
+  const timeline = form.fields.timeline;
+  const chipLabels = chipsAfter(timeline).children.map(b => b.textContent);
+  assert.deepEqual(chipLabels, TIMELINE_CHIP_VALUES);
+  assert.equal(timeline.selectedIndex, 0);
+  assert.equal(timeline.value, '');
+  clickChip(timeline, '1–3 months');
+  assert.equal(timeline.value, '1–3 months');
+  assert.equal(timeline.selectedIndex, 2);
+  assert.ok(timeline.selectedIndex > 0);
+  assert.ok(timeline.options[timeline.selectedIndex]);
+  clickChip(timeline, 'Just exploring / unsure');
+  assert.equal(timeline.value, 'Just exploring / unsure');
+  assert.equal(timeline.selectedIndex, 6);
+});
+
+test('concern chips toggle the matching checkbox rather than assigning .value on the list', () => {
+  const form = portalLikeForm();
+  const list = form.elements.namedItem('concerns');
+  Object.defineProperty(list, 'value', {
+    set() { throw new Error('must not assign .value on the checkbox NodeList'); },
+    get() { return ''; }
+  });
+  installBuyerGuidance(form, fakeDocument(), BUYER_GUIDANCE);
+  const paying = form.boxes.find(b => b.value === 'Paying too much');
+  assert.equal(paying.checked, false);
+  clickChip(form.concernChoices, 'Paying too much');
+  assert.equal(paying.checked, true);
+  clickChip(form.concernChoices, 'Paying too much');
+  assert.equal(paying.checked, false);
+  clickChip(form.concernChoices, 'I do not know what I do not know');
+  assert.equal(form.boxes.find(b => b.value === 'I do not know what I do not know').checked, true);
+});
+
+test('identity fields still have no I do not know or guided chips', () => {
+  const form = portalLikeForm();
+  installBuyerGuidance(form, fakeDocument(), BUYER_GUIDANCE);
+  for (const name of ['first_name', 'last_name', 'email', 'phone']) {
+    assert.equal(chipsAfter(form.fields[name]), null);
+    assert.equal(form.fields[name].dataset.guided, undefined);
+  }
+  const html = addBuyerFirstClarity(questionnaire, '/questionnaire');
+  assert.doesNotMatch(html, /first_name:\{help:/);
+  assert.doesNotMatch(html, /last_name:\{help:/);
+  assert.doesNotMatch(html, /email:\{help:/);
+  assert.doesNotMatch(html, /phone:\{help:/);
+  const identityBlock = html.match(/first_name[\s\S]{0,200}I’m not sure yet/);
+  assert.equal(identityBlock, null);
+});
+
+test('a throw on one field does not abort remaining fields including notes', () => {
+  const form = portalLikeForm();
+  const broken = {
+    nodeType: 1,
+    tagName: 'TEXTAREA',
+    type: 'textarea',
+    get dataset() { throw new Error('dataset boom'); }
+  };
+  const orig = form.elements.namedItem.bind(form.elements);
+  form.elements.namedItem = (name) => name === 'why' ? broken : orig(name);
+  assert.doesNotThrow(() => installBuyerGuidance(form, fakeDocument(), BUYER_GUIDANCE));
+  assert.ok(chipsAfter(form.fields.notes), 'notes chips must survive an earlier field throw');
+  assert.ok(chipsAfter(form.concernChoices), 'concerns chips must survive an earlier field throw');
+});
+
+test('injector is type-aware for worker.js text concerns and timeline', () => {
+  const form = workerLikeForm();
+  installBuyerGuidance(form, fakeDocument(), BUYER_GUIDANCE);
+  assert.ok(chipsAfter(form.fields.concerns));
+  assert.ok(chipsAfter(form.fields.timeline));
+  clickChip(form.fields.timeline, 'Immediately / within 30 days');
+  assert.equal(form.fields.timeline.value, 'Immediately / within 30 days');
+  clickChip(form.fields.concerns, 'Hidden property problems');
+  assert.equal(form.fields.concerns.value, 'Hidden property problems');
+});
+
+test('live portal questionnaire option strings stay 1:1 with chips', () => {
+  const portal = readFileSync(new URL('../src/portal-worker.js', import.meta.url), 'utf8');
+  for (const value of TIMELINE_CHIP_VALUES) {
+    assert.ok(portal.includes(`<option>${value}</option>`), value);
+  }
+  const joined = CONCERN_CHIP_VALUES.map(v => `'${v}'`).join(',');
+  assert.ok(portal.includes(joined), 'concern checkbox labels must match chips 1:1');
 });


### PR DESCRIPTION
## Objective
Restore guided-answer chips on the live Buyer Experience form (`id=buyerExperienceForm`) so concerns, notes, and timeline all receive usable suggestions.

## Defect
1. The chip injector called `form.elements.namedItem(name)` and treated the result as an element. For the live `concerns` checkbox group that returns a `RadioNodeList`, `field.dataset.guided = 'yes'` threw, the `for-of` over the guide map aborted, and **notes never got chips**.
2. Timeline chips were free-text strings (`As soon as it makes sense`, `Within 3–6 months`, `I’m not sure yet`, …) that do **not** match the live `<select name="timeline">` option values, so tapping a chip did not select a real option.

## Fix
- Extract a type-aware injector (`secure-platform/src/buyer-guidance.js`) used by `BUYER_GUIDANCE_JS`.
- Resolve a real Element from `namedItem`: if the result is a `RadioNodeList` / collection (no `nodeType === 1`), use the first control. Never call `dataset` / `insertAdjacentElement` on a NodeList.
- Insert help + chips after the group container (`#concernChoices` or closest `.choices` / `.group`) for checkbox groups.
- Wrap each field in try/catch so a throw/mismatch on one field cannot abort remaining fields (notes still get chips).
- Timeline chips are the six live option strings, 1:1. Clicking a chip sets `select.value` to that exact option and dispatches `input`/`change`.
- Concerns chips are the nine live checkbox labels, 1:1. Clicking a chip toggles the matching checkbox instead of assigning `.value` on the NodeList.
- `why` / `location` / `notes` remain text fields; chips still fill the textarea/input. Uncertainty language stays on why/timeline/location/concerns/notes only.
- Identity/factual fields (`first_name`, `last_name`, `email`, `phone`) still do not get guided chips.
- Injector is type-aware so the worker.js questionnaire (textarea concerns / input timeline) still works without rewriting the form.

## How verified
- Injector does **not** throw on a form with a concerns checkbox `RadioNodeList`; after run, **both** the concerns group and notes have chips.
- Timeline chips equal the six option values; applying a chip sets `select.value` to that option (`selectedIndex` is a real option, not empty).
- Concern chips toggle the matching checkbox and never assign `.value` on the NodeList.
- Identity fields still have no “I don't know” chips.
- Existing secure-platform suite + new tests: **52 pass / 0 fail** (`issue36.test.mjs` 15/15 including 8 new tests; `issue29.test.mjs` + `bimatrix.test.mjs` also green).

## What was not done
- No merge
- No deploy / no wrangler deploy
- No production D1
- No MLS enable
- No PAT
- No client PII
- Did not reuse PRs #26 / #27
- Did not rewrite the whole form
- Did not add compensation numbers or weaken auth