### PR TITLE
Add public-site acquisition instrumentation foundation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,9 +37,6 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Run acquisition measurement tests
-        run: node --test themes/hbe/static/js/acquisition.test.mjs
-
       - name: Setup Pages
         if: github.event_name != 'pull_request'
         id: pages
@@ -75,7 +72,6 @@ jobs:
           test -f public/index.html
           test -f public/css/style.css
           test -f public/js/nav.js
-          test -f public/js/acquisition.js
           test -f public/sitemap.xml
           test -f public/robots.txt
 
@@ -104,8 +100,6 @@ jobs:
               raise SystemExit('VALIDATION FAILURE: homepage does not reference /css/style.css.')
           if '/js/nav.js' not in homepage.scripts:
               raise SystemExit('VALIDATION FAILURE: homepage does not reference /js/nav.js.')
-          if '/js/acquisition.js' not in homepage.scripts:
-              raise SystemExit('VALIDATION FAILURE: homepage does not reference /js/acquisition.js.')
 
           root = ET.parse('public/sitemap.xml').getroot()
           locs = [e.text.strip() for e in root.iter() if e.tag.endswith('loc') and e.text]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,9 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Run acquisition measurement tests
+        run: node --test themes/hbe/static/js/acquisition.test.mjs
+
       - name: Setup Pages
         if: github.event_name != 'pull_request'
         id: pages
@@ -72,6 +75,7 @@ jobs:
           test -f public/index.html
           test -f public/css/style.css
           test -f public/js/nav.js
+          test -f public/js/acquisition.js
           test -f public/sitemap.xml
           test -f public/robots.txt
 
@@ -100,6 +104,8 @@ jobs:
               raise SystemExit('VALIDATION FAILURE: homepage does not reference /css/style.css.')
           if '/js/nav.js' not in homepage.scripts:
               raise SystemExit('VALIDATION FAILURE: homepage does not reference /js/nav.js.')
+          if '/js/acquisition.js' not in homepage.scripts:
+              raise SystemExit('VALIDATION FAILURE: homepage does not reference /js/acquisition.js.')
 
           root = ET.parse('public/sitemap.xml').getroot()
           locs = [e.text.strip() for e in root.iter() if e.tag.endswith('loc') and e.text]

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -45,6 +45,8 @@ Sensitive document features are intentionally separate from ordinary BuyerUI acc
 
 Hosting and infrastructure providers may process technical information needed to deliver and protect the service, such as IP address, browser/device information, request timestamps, requested routes, and security/performance information.
 
+The public informational site may also record coarse, first-party acquisition events in the browser (for example, that a page was viewed and which high-level channel the visit appears to have come from). Those events use the page pathname and sanitized campaign tokens only. They do not include names, email addresses, phone numbers, Buyer Experience answers, household identifiers, or Buyer Journey portal behavior. An optional aggregate Cloudflare Web Analytics beacon may be enabled later; it is off by default. We do not use public-site measurement for advertising or cross-site targeting.
+
 We do not use this information to build advertising profiles or sell behavioral data.
 
 ---
@@ -76,6 +78,8 @@ Information should help us serve the buyer; it should not become a tool for mani
 
 The secure HBE Buyer Journey uses Cloudflare infrastructure, including Cloudflare Workers and D1 database services, to deliver the BuyerUI and store submitted buyer-system data. Cloudflare may process technical request and security information as part of operating those services.
 
+The public informational site may optionally use Cloudflare Web Analytics for aggregate, cookie-free measurement. That beacon is off unless a site token is configured.
+
 ### GitHub Pages
 
 The public HBE informational website is hosted on GitHub Pages. GitHub may log standard server access data as part of normal hosting operations.
@@ -84,7 +88,7 @@ The public HBE informational website is hosted on GitHub Pages. GitHub may log s
 
 ## Cookies and Sessions
 
-The public informational site may use standard browser technologies needed for functionality or aggregate analytics if enabled.
+The public informational site may use standard browser technologies needed for functionality. Coarse first-party acquisition events may be stored in session storage for the visit. Optional aggregate analytics (Cloudflare Web Analytics) may be enabled; they are off by default. We do not set advertising cookies on the public site.
 
 The secure Buyer Journey uses a session cookie to keep an authorized buyer signed in. If a buyer deliberately selects a "remember this device" option, that session may persist longer than a normal browser session.
 

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -45,7 +45,7 @@ Sensitive document features are intentionally separate from ordinary BuyerUI acc
 
 Hosting and infrastructure providers may process technical information needed to deliver and protect the service, such as IP address, browser/device information, request timestamps, requested routes, and security/performance information.
 
-The public informational site may also record coarse, first-party acquisition events in the browser (for example, that a page was viewed and which high-level channel the visit appears to have come from). Those events use the page pathname and sanitized campaign tokens only. They do not include names, email addresses, phone numbers, Buyer Experience answers, household identifiers, or Buyer Journey portal behavior. An optional aggregate Cloudflare Web Analytics beacon may be enabled later; it is off by default. We do not use public-site measurement for advertising or cross-site targeting.
+The public informational site includes a first-party instrumentation foundation that may record coarse events in the browser session only (for example, that a page was viewed and which high-level channel the visit appears to have come from). Those events stay in memory and session storage until a later gated collector exists; they are not sent to a network analytics product today. They use the page pathname and sanitized campaign tokens only. They do not include names, email addresses, phone numbers, Buyer Experience answers, household identifiers, or Buyer Journey portal behavior. An optional aggregate Cloudflare Web Analytics beacon may be enabled later; it is a separate pageview product, it does not receive these custom events, and it is off by default. We do not use this public-site instrumentation for advertising or cross-site targeting.
 
 We do not use this information to build advertising profiles or sell behavioral data.
 
@@ -78,7 +78,7 @@ Information should help us serve the buyer; it should not become a tool for mani
 
 The secure HBE Buyer Journey uses Cloudflare infrastructure, including Cloudflare Workers and D1 database services, to deliver the BuyerUI and store submitted buyer-system data. Cloudflare may process technical request and security information as part of operating those services.
 
-The public informational site may optionally use Cloudflare Web Analytics for aggregate, cookie-free measurement. That beacon is off unless a site token is configured.
+The public informational site may optionally use Cloudflare Web Analytics for aggregate, cookie-free pageviews. That beacon is a separate product from the first-party custom events, does not receive those events, and is off unless a site token is configured.
 
 ### GitHub Pages
 
@@ -88,7 +88,7 @@ The public HBE informational website is hosted on GitHub Pages. GitHub may log s
 
 ## Cookies and Sessions
 
-The public informational site may use standard browser technologies needed for functionality. Coarse first-party acquisition events may be stored in session storage for the visit. Optional aggregate analytics (Cloudflare Web Analytics) may be enabled; they are off by default. We do not set advertising cookies on the public site.
+The public informational site may use standard browser technologies needed for functionality. Coarse first-party instrumentation events may be stored in session storage for the visit only, until a later gated collector exists. Optional Cloudflare Web Analytics is a separate pageview product and is off by default; it does not receive those custom events. We do not set advertising cookies on the public site.
 
 The secure Buyer Journey uses a session cookie to keep an authorized buyer signed in. If a buyer deliberately selects a "remember this device" option, that session may persist longer than a normal browser session.
 

--- a/docs/ACQUISITION_MEASUREMENT.md
+++ b/docs/ACQUISITION_MEASUREMENT.md
@@ -93,4 +93,4 @@ From the repository root:
 node --test themes/hbe/static/js/acquisition.test.mjs
 ```
 
-The deploy workflow also runs these tests and asserts that the homepage references both `/js/nav.js` and `/js/acquisition.js`.
+The current GitHub Pages deploy workflow requires `/js/nav.js` on the homepage and allows additional public scripts, so `acquisition.js` can ship without a workflow change. A follow-up that has `workflow` scope can also run `node --test` in CI and require `/js/acquisition.js`.

--- a/docs/ACQUISITION_MEASUREMENT.md
+++ b/docs/ACQUISITION_MEASUREMENT.md
@@ -1,0 +1,96 @@
+# Public-site acquisition measurement
+
+The public HBE site records a small set of first-party, coarse events so we can tell whether people are finding the informational pages and choosing to enter the Buyer Journey. Measurement is pathname- and channel-level only. It does not collect names, email addresses, phone numbers, Buyer Experience answers, household identifiers, or Buyer Journey portal behavior.
+
+This document describes the public site only (`hbexperts.com`, Hugo theme `hbe`, GitHub Pages). The secure Buyer Journey at `buyer.hbexperts.com` is out of scope.
+
+## Events
+
+| Event | When it fires | Fields | Privacy notes |
+| --- | --- | --- | --- |
+| `discovery_view` | Once on `DOMContentLoaded` for each public page load | `event`, `page_path` (pathname only), `channel`, optional `utm_source` / `utm_medium` / `utm_campaign`, optional `referrer_host`, `ts` | No names, emails, phones, questionnaire fields, or full referrer URLs. UTM values are stored only if they look like short non-PII tokens (max 64 chars; email/phone/URL-like values are dropped). `utm_content` and `utm_term` may be read for channel classification but are not emitted. |
+| `journey_entry_click` | Click on an anchor whose host is `buyer.hbexperts.com` | Same coarse fields as `discovery_view`, plus `dest_path` (destination pathname only) | Destination query strings are not recorded. The outbound URL may receive only `hbe_ch`, `hbe_lp`, and `hbe_ft` (coarse tokens / landing path). |
+| `consultation_cta_click` | Click on a same-site anchor to `/strategy-session/` or `/contact/` | Same coarse fields as `journey_entry_click` | Internal consultation CTAs are not annotated with extra query params. `tel:` and `mailto:` links are ignored so phone numbers and addresses are never captured as destinations. |
+
+Each event is also dispatched as a `CustomEvent` named `hbe:acquisition` on `document` (`event.detail` is the payload) and appended to an in-memory ring buffer `window.__HBE_ACQ_EVENTS__` (max 20) for local verification without a network sink.
+
+First-touch coarse attribution is stored in `sessionStorage` key `hbe_acq_v1` for the browser session only. The module does not use `localStorage` and does not set tracking cookies.
+
+## Channel classification
+
+`channel` is one of: `paid` | `referral` | `local` | `relocation` | `organic` | `direct` | `unknown`.
+
+Rules, in order:
+
+1. **relocation** — `utm_campaign` or `utm_content` contains the token `relocation` (split on non-alphanumeric characters). Never inferred from geography, copy, or referrer.
+2. **local** — the same fields contain the token `local`. `allocate` / `locale` do not match. Never inferred from IP or location.
+3. **paid** — `utm_medium` is one of `cpc`, `ppc`, `paid`, `paid_social`, `paid-social`, `display`, `ads` (and close variants), **or** `utm_source` looks like an ad platform (`googleads`, `fb`, `meta`, `bing`, and close variants).
+4. **organic** — the external referrer host is a known search engine, **or** `utm_medium=organic`.
+5. **referral** — there is an external referrer host that is not a search engine.
+6. **direct** — no surviving UTM tokens and no external referrer.
+7. **unknown** — fallback (for example `utm_medium=email` with no other signal).
+
+Same-site referrers (`hbexperts.com` / `www.hbexperts.com`) are ignored. They are not treated as referrals, and they do not overwrite first-touch. On later public pages in the same session, a direct/empty signal reuses the first-touch channel so internal navigation does not look like a new direct visit.
+
+`document.referrer` is reduced to hostname only before storage or emission. Paths and query strings (which might contain search terms or other leakage) are discarded.
+
+## What is measurable automatically vs derived or manual
+
+Automatically on the public site:
+
+- Page views of public Hugo pages, with coarse channel and optional sanitized UTM tokens.
+- Clicks from the public site into `buyer.hbexperts.com` (including header “Start Buyer Experience” and homepage “Explore the Buyer Journey”).
+- Clicks to the public Strategy Session and Contact pages.
+
+Optional, off by default:
+
+- Cloudflare Web Analytics (free, aggregate, cookie-free). See below.
+
+Coarse hosting logs:
+
+- GitHub Pages may log standard server access data as part of hosting. Those logs are not this module and are not buyer-level analytics.
+
+Out of scope / manual or secure-platform only:
+
+- Qualified Buyer Journey completion, questionnaire answers, household identifiers, and portal behavior live on the secure platform and are **not** instrumented here.
+- Spend, targets, campaign sequencing, and creative strategy are not part of this public measurement surface.
+- No new paid analytics or SEO product is required for this module to work.
+
+## How to enable optional Cloudflare Web Analytics
+
+Cloudflare Web Analytics is $0 on Cloudflare accounts and is **off by default**. This PR does not hardcode a site token and CI/build needs no secrets.
+
+To enable later:
+
+1. In the Cloudflare dashboard, add a Web Analytics site and copy the site token.
+2. Set the token in `hugo.toml`:
+
+```toml
+[params]
+  # Optional. Cloudflare Web Analytics site token (free). Leave empty to keep first-party-only measurement.
+  cloudflareWebAnalyticsToken = ""
+```
+
+3. Redeploy the public Hugo site. `themes/hbe/layouts/_default/baseof.html` injects the standard privacy-oriented CF beacon only when that param is non-empty.
+
+If the token is empty, measurement stays first-party only (CustomEvent + sessionStorage + in-memory ring buffer). An optional runtime sink `window.__HBE_ACQ__.send(payload)` may be provided by tests or a future first-party collector; it is not required.
+
+## Non-goals
+
+- No buyer answers, names, emails, phones, or household IDs.
+- No instrumentation of `buyer.hbexperts.com` portal pages from this public repo.
+- No D1, HBEUI/BuyerUI auth, Cloudflare Access, MLS, or sensitive-upload changes.
+- No weakening of `no-store` / `noindex` on secure surfaces.
+- No new paid analytics, tag manager, or SEO product.
+- No advertising, remarketing, or cross-site targeting pixels.
+- No campaign spend, targeting, or sequencing documentation in this public repo.
+
+## Tests
+
+From the repository root:
+
+```bash
+node --test themes/hbe/static/js/acquisition.test.mjs
+```
+
+The deploy workflow also runs these tests and asserts that the homepage references both `/js/nav.js` and `/js/acquisition.js`.

--- a/docs/ACQUISITION_MEASUREMENT.md
+++ b/docs/ACQUISITION_MEASUREMENT.md
@@ -1,20 +1,26 @@
-# Public-site acquisition measurement
+# Public-site acquisition instrumentation foundation
 
-The public HBE site records a small set of first-party, coarse events so we can tell whether people are finding the informational pages and choosing to enter the Buyer Journey. Measurement is pathname- and channel-level only. It does not collect names, email addresses, phone numbers, Buyer Experience answers, household identifiers, or Buyer Journey portal behavior.
+This is a **client-side instrumentation foundation**, not completed acquisition measurement. The public HBE site records a small set of first-party, coarse events in the browser so a later gated collector can subscribe. Until that collector exists, events are **session/in-memory only**: a `CustomEvent` named `hbe:acquisition`, first-touch in `sessionStorage`, and an in-memory ring buffer. Nothing in this module sends those custom events to a network analytics product.
 
-This document describes the public site only (`hbexperts.com`, Hugo theme `hbe`, GitHub Pages). The secure Buyer Journey at `buyer.hbexperts.com` is out of scope.
+Events are pathname- and channel-level only. The foundation does not collect names, email addresses, phone numbers, Buyer Experience answers, household identifiers, or Buyer Journey portal behavior.
+
+Optional Cloudflare Web Analytics is a **separate pageview product**. It does not receive these custom events. It remains off by default.
+
+This document describes the public site only (`hbexperts.com`, Hugo theme `hbe`, GitHub Pages). The secure Buyer Journey at `buyer.hbexperts.com` is out of scope. Outbound links to that host are left clean: this module does **not** append `hbe_ch`, `hbe_lp`, or `hbe_ft` (or any other acquisition query params) until a secure-side consumer exists.
 
 ## Events
 
 | Event | When it fires | Fields | Privacy notes |
 | --- | --- | --- | --- |
-| `discovery_view` | Once on `DOMContentLoaded` for each public page load | `event`, `page_path` (pathname only), `channel`, optional `utm_source` / `utm_medium` / `utm_campaign`, optional `referrer_host`, `ts` | No names, emails, phones, questionnaire fields, or full referrer URLs. UTM values are stored only if they look like short non-PII tokens (max 64 chars; email/phone/URL-like values are dropped). `utm_content` and `utm_term` may be read for channel classification but are not emitted. |
-| `journey_entry_click` | Click on an anchor whose host is `buyer.hbexperts.com` | Same coarse fields as `discovery_view`, plus `dest_path` (destination pathname only) | Destination query strings are not recorded. The outbound URL may receive only `hbe_ch`, `hbe_lp`, and `hbe_ft` (coarse tokens / landing path). |
+| `discovery_view` | Once on `DOMContentLoaded` for each public page load | `event`, `page_path` (pathname only), `channel`, optional `utm_source` / `utm_medium` / `utm_campaign`, optional `referrer_host`, `ts` | No names, emails, phones, questionnaire fields, or full referrer URLs. UTM values are stored only if they look like short non-PII tokens (max 64 chars; email/phone/URL-like values are dropped). `utm_content` and `utm_term` may be read for channel classification but are not emitted. Session/in-memory only until a later gated collector exists. |
+| `journey_entry_click` | Click on an anchor whose host is `buyer.hbexperts.com` | Same coarse fields as `discovery_view`, plus `dest_path` (destination pathname only) | Destination query strings are not recorded. The outbound URL is **not** mutated: no `hbe_ch`, `hbe_lp`, or `hbe_ft` (or other acquisition params) are appended. |
 | `consultation_cta_click` | Click on a same-site anchor to `/strategy-session/` or `/contact/` | Same coarse fields as `journey_entry_click` | Internal consultation CTAs are not annotated with extra query params. `tel:` and `mailto:` links are ignored so phone numbers and addresses are never captured as destinations. |
 
-Each event is also dispatched as a `CustomEvent` named `hbe:acquisition` on `document` (`event.detail` is the payload) and appended to an in-memory ring buffer `window.__HBE_ACQ_EVENTS__` (max 20) for local verification without a network sink.
+Each event is dispatched as a `CustomEvent` named `hbe:acquisition` on `document` (`event.detail` is the payload) and appended to an in-memory ring buffer `window.__HBE_ACQ_EVENTS__` (max 20). That is local verification, not a shipped collector.
 
 First-touch coarse attribution is stored in `sessionStorage` key `hbe_acq_v1` for the browser session only. The module does not use `localStorage` and does not set tracking cookies.
+
+An optional runtime sink `window.__HBE_ACQ__.send(payload)` may be provided by tests or a **later gated collector**; it is not wired to any network destination in this PR.
 
 ## Channel classification
 
@@ -34,17 +40,17 @@ Same-site referrers (`hbexperts.com` / `www.hbexperts.com`) are ignored. They ar
 
 `document.referrer` is reduced to hostname only before storage or emission. Paths and query strings (which might contain search terms or other leakage) are discarded.
 
-## What is measurable automatically vs derived or manual
+## What is instrumented automatically vs derived or manual
 
-Automatically on the public site:
+Automatically on the public site (session/in-memory only until a later gated collector exists):
 
 - Page views of public Hugo pages, with coarse channel and optional sanitized UTM tokens.
-- Clicks from the public site into `buyer.hbexperts.com` (including header “Start Buyer Experience” and homepage “Explore the Buyer Journey”).
+- Clicks from the public site into `buyer.hbexperts.com` (including header “Start Buyer Experience” and homepage “Explore the Buyer Journey”). Those clicks fire events; they do **not** rewrite the destination URL.
 - Clicks to the public Strategy Session and Contact pages.
 
-Optional, off by default:
+Optional, off by default, and **not** a consumer of these custom events:
 
-- Cloudflare Web Analytics (free, aggregate, cookie-free). See below.
+- Cloudflare Web Analytics (free, aggregate, cookie-free pageviews). See below.
 
 Coarse hosting logs:
 
@@ -53,12 +59,13 @@ Coarse hosting logs:
 Out of scope / manual or secure-platform only:
 
 - Qualified Buyer Journey completion, questionnaire answers, household identifiers, and portal behavior live on the secure platform and are **not** instrumented here.
-- Spend, targets, campaign sequencing, and creative strategy are not part of this public measurement surface.
-- No new paid analytics or SEO product is required for this module to work.
+- Spend, targets, campaign sequencing, and creative strategy are not part of this public instrumentation surface.
+- No new paid analytics or SEO product is required for this foundation.
+- A gated first-party collector that actually stores or forwards these events is a later step, not this PR.
 
 ## How to enable optional Cloudflare Web Analytics
 
-Cloudflare Web Analytics is $0 on Cloudflare accounts and is **off by default**. This PR does not hardcode a site token and CI/build needs no secrets.
+Cloudflare Web Analytics is $0 on Cloudflare accounts and is **off by default**. It is a separate aggregate **pageview** product. It does not receive `hbe:acquisition` custom events, the ring buffer, or sessionStorage first-touch. This PR does not hardcode a site token and CI/build needs no secrets.
 
 To enable later:
 
@@ -67,18 +74,20 @@ To enable later:
 
 ```toml
 [params]
-  # Optional. Cloudflare Web Analytics site token (free). Leave empty to keep first-party-only measurement.
+  # Optional. Cloudflare Web Analytics site token (free). Leave empty to keep first-party-only instrumentation.
   cloudflareWebAnalyticsToken = ""
 ```
 
 3. Redeploy the public Hugo site. `themes/hbe/layouts/_default/baseof.html` injects the standard privacy-oriented CF beacon only when that param is non-empty.
 
-If the token is empty, measurement stays first-party only (CustomEvent + sessionStorage + in-memory ring buffer). An optional runtime sink `window.__HBE_ACQ__.send(payload)` may be provided by tests or a future first-party collector; it is not required.
+If the token is empty, no CF beacon is loaded. Public-site custom events remain session/in-memory only.
 
 ## Non-goals
 
+- This is not completed acquisition measurement; it is an instrumentation foundation.
 - No buyer answers, names, emails, phones, or household IDs.
 - No instrumentation of `buyer.hbexperts.com` portal pages from this public repo.
+- No appending of `hbe_ch` / `hbe_lp` / `hbe_ft` (or similar) onto Buyer Journey URLs.
 - No D1, HBEUI/BuyerUI auth, Cloudflare Access, MLS, or sensitive-upload changes.
 - No weakening of `no-store` / `noindex` on secure surfaces.
 - No new paid analytics, tag manager, or SEO product.

--- a/hugo.toml
+++ b/hugo.toml
@@ -12,7 +12,7 @@ theme = "hbe"
   counties = "Summit, Stark, Medina, Wayne & Cuyahoga Counties"
   informationLastUpdated = "September 2, 2026"
 
-  # Optional. Cloudflare Web Analytics site token (free). Leave empty to keep first-party-only measurement.
+  # Optional. Cloudflare Web Analytics site token (free). Separate pageview product; does not receive first-party custom events. Leave empty to keep first-party-only instrumentation.
   cloudflareWebAnalyticsToken = ""
 
 [menu]

--- a/hugo.toml
+++ b/hugo.toml
@@ -12,6 +12,9 @@ theme = "hbe"
   counties = "Summit, Stark, Medina, Wayne & Cuyahoga Counties"
   informationLastUpdated = "September 2, 2026"
 
+  # Optional. Cloudflare Web Analytics site token (free). Leave empty to keep first-party-only measurement.
+  cloudflareWebAnalyticsToken = ""
+
 [menu]
   [[menu.main]]
     name = "About"

--- a/themes/hbe/layouts/_default/baseof.html
+++ b/themes/hbe/layouts/_default/baseof.html
@@ -6,17 +6,24 @@
   <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | HomeBuyer Experts{{ end }}</title>
   <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
   {{ with .Params.robots }}<meta name="robots" content="{{ . }}">{{ end }}
+  {{ with .Site.Params.cloudflareWebAnalyticsToken }}
+  <meta name="hbe-cf-wa-token" content="{{ . }}">
+  {{ end }}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
+  {{ with .Site.Params.cloudflareWebAnalyticsToken }}
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": {{ . | jsonify }}}'></script>
+  {{ end }}
 </head>
-<body>
+<body data-hbe-page="{{ if .IsHome }}home{{ else if eq .RelPermalink "/strategy-session/" }}strategy{{ else if eq .RelPermalink "/about/" }}about{{ else }}other{{ end }}">
   {{ partial "header.html" . }}
   <main>
     {{ block "main" . }}{{ end }}
   </main>
   {{ partial "footer.html" . }}
   <script src="{{ "js/nav.js" | relURL }}"></script>
+  <script src="{{ "js/acquisition.js" | relURL }}"></script>
 </body>
 </html>

--- a/themes/hbe/static/js/acquisition.js
+++ b/themes/hbe/static/js/acquisition.js
@@ -1,0 +1,513 @@
+/**
+ * HBE public-site acquisition measurement (first-party, privacy-safe).
+ *
+ * Records coarse discovery and CTA events only: pathname, channel, sanitized
+ * UTM tokens, and referrer host. No names, emails, phones, questionnaire
+ * answers, household IDs, cookies, or localStorage.
+ *
+ * Channel heuristics (see docs/ACQUISITION_MEASUREMENT.md):
+ *   relocation / local — ONLY when utm_campaign or utm_content contains that
+ *     token (explicit coarse tagging). Never inferred from geo or copy.
+ *   paid — utm_medium in cpc/ppc/paid/paid_social/display/ads (and close
+ *     variants) OR utm_source looks like an ad platform (googleads, fb,
+ *     meta, bing, ...)
+ *   organic — referrer host is a known search engine OR utm_medium=organic
+ *   referral — external referrer host that is not a search engine
+ *   direct — no surviving UTM tokens and no external referrer
+ *   unknown — fallback
+ *
+ * Explicit local/relocation tokens take precedence over paid/organic/referral.
+ * Same-site referrers are ignored. First-touch is stored in sessionStorage
+ * key hbe_acq_v1 and is not overwritten during the session.
+ */
+(function (root) {
+  'use strict';
+
+  var STORAGE_KEY = 'hbe_acq_v1';
+  var MAX_EVENTS = 20;
+  var MAX_UTM_LEN = 64;
+  var MAX_PATH_LEN = 128;
+  var MAX_HOST_LEN = 253;
+  var CHANNELS = ['paid', 'referral', 'local', 'relocation', 'organic', 'direct', 'unknown'];
+  var PAYLOAD_KEYS = [
+    'event', 'page_path', 'channel', 'utm_source', 'utm_medium',
+    'utm_campaign', 'referrer_host', 'ts', 'dest_path'
+  ];
+  var JOURNEY_HOST = 'buyer.hbexperts.com';
+  var CONSULTATION_PATHS = { '/strategy-session': 1, '/contact': 1 };
+
+  var PAID_MEDIUMS = {
+    cpc: 1, ppc: 1, paid: 1, paid_social: 1, 'paid-social': 1, paidsocial: 1,
+    display: 1, ads: 1, cpm: 1, cpa: 1, paidsearch: 1, 'paid-search': 1,
+    'paid search': 1
+  };
+  var PAID_SOURCES = {
+    googleads: 1, google_ads: 1, 'google-ads': 1, adwords: 1, gads: 1,
+    fb: 1, facebook: 1, meta: 1, instagram: 1, ig: 1,
+    bing: 1, bingads: 1, 'bing-ads': 1,
+    tiktok: 1, linkedin: 1, twitter: 1, pinterest: 1
+  };
+
+  function looksLikeEmail(value) {
+    return /[^\s@]+@[^\s@]+\.[^\s@]+/.test(String(value || ''));
+  }
+
+  function looksLikePhone(value) {
+    var digits = String(value || '').replace(/\D/g, '');
+    return digits.length >= 10 && digits.length <= 15;
+  }
+
+  function sanitizeUtm(value) {
+    if (value == null) return '';
+    var s = String(value).trim();
+    if (!s) return '';
+    if (/@/.test(s) || looksLikeEmail(s)) return '';
+    if (looksLikePhone(s)) return '';
+    if (/^https?:\/\//i.test(s)) return '';
+    if (/[\u0000-\u001f]/.test(s)) return '';
+    if (s.length > MAX_UTM_LEN) s = s.slice(0, MAX_UTM_LEN);
+    return s;
+  }
+
+  function sanitizePath(value) {
+    if (value == null) return '';
+    var s = String(value).split('?')[0].split('#')[0].trim();
+    if (!s) return '';
+    if (s.charAt(0) !== '/') s = '/' + s;
+    if (s.length > MAX_PATH_LEN) s = s.slice(0, MAX_PATH_LEN);
+    if (s.indexOf('..') !== -1) return '';
+    if (!/^\/[A-Za-z0-9/_\-.~]*$/.test(s)) return '';
+    return s;
+  }
+
+  function pagePath(value) {
+    var s = sanitizePath(value);
+    return s || '/';
+  }
+
+  function normalizeChannel(value) {
+    var c = String(value || '').toLowerCase();
+    for (var i = 0; i < CHANNELS.length; i++) {
+      if (CHANNELS[i] === c) return c;
+    }
+    return 'unknown';
+  }
+
+  function sameSite(host, siteHost) {
+    if (!host || !siteHost) return false;
+    host = String(host).toLowerCase();
+    siteHost = String(siteHost).toLowerCase();
+    if (host === siteHost) return true;
+    if (host === 'www.' + siteHost || siteHost === 'www.' + host) return true;
+    return false;
+  }
+
+  function referrerHost(referrer, siteHost) {
+    if (!referrer) return '';
+    try {
+      var u = new URL(String(referrer));
+      var host = (u.hostname || '').toLowerCase();
+      if (!host) return '';
+      if (sameSite(host, siteHost)) return '';
+      if (host.length > MAX_HOST_LEN) host = host.slice(0, MAX_HOST_LEN);
+      return host;
+    } catch (err) {
+      return '';
+    }
+  }
+
+  function isSearchEngineHost(host) {
+    if (!host) return false;
+    var h = String(host).toLowerCase();
+    if (/(^|\.)google\.[a-z.]+$/.test(h)) return true;
+    if (/(^|\.)bing\.com$/.test(h)) return true;
+    if (/(^|\.)yahoo\.[a-z.]+$/.test(h)) return true;
+    if (/(^|\.)duckduckgo\.com$/.test(h)) return true;
+    if (/(^|\.)baidu\.[a-z.]+$/.test(h)) return true;
+    if (/(^|\.)yandex\.[a-z.]+$/.test(h)) return true;
+    if (/(^|\.)brave\.com$/.test(h)) return true;
+    if (/(^|\.)ecosia\.org$/.test(h)) return true;
+    if (/(^|\.)startpage\.com$/.test(h)) return true;
+    return false;
+  }
+
+  function tokenList(value) {
+    return String(value || '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  }
+
+  function hasCampaignToken(utms, token) {
+    var fields = [(utms && utms.utm_campaign) || '', (utms && utms.utm_content) || ''];
+    for (var i = 0; i < fields.length; i++) {
+      var tokens = tokenList(fields[i]);
+      for (var j = 0; j < tokens.length; j++) {
+        if (tokens[j] === token) return true;
+      }
+    }
+    return false;
+  }
+
+  function hasAnyUtm(utms) {
+    if (!utms) return false;
+    return !!(utms.utm_source || utms.utm_medium || utms.utm_campaign || utms.utm_content || utms.utm_term);
+  }
+
+  function classifyChannel(utms, host) {
+    utms = utms || {};
+    host = host || '';
+    if (hasCampaignToken(utms, 'relocation')) return 'relocation';
+    if (hasCampaignToken(utms, 'local')) return 'local';
+    var medium = String(utms.utm_medium || '').toLowerCase();
+    var source = String(utms.utm_source || '').toLowerCase();
+    if (PAID_MEDIUMS[medium] || PAID_SOURCES[source]) return 'paid';
+    if (medium === 'organic' || isSearchEngineHost(host)) return 'organic';
+    if (host && !isSearchEngineHost(host)) return 'referral';
+    if (!hasAnyUtm(utms) && !host) return 'direct';
+    return 'unknown';
+  }
+
+  function readUtms(search) {
+    var params;
+    try {
+      params = new URLSearchParams(search || '');
+    } catch (err) {
+      return {};
+    }
+    var keys = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'];
+    var out = {};
+    for (var i = 0; i < keys.length; i++) {
+      var clean = sanitizeUtm(params.get(keys[i]));
+      if (clean) out[keys[i]] = clean;
+    }
+    return out;
+  }
+
+  function buildPayload(eventName, ctx) {
+    ctx = ctx || {};
+    var payload = {
+      event: String(eventName || ''),
+      page_path: pagePath(ctx.page_path),
+      channel: normalizeChannel(ctx.channel),
+      ts: ctx.ts || new Date().toISOString()
+    };
+    var source = sanitizeUtm(ctx.utm_source);
+    var medium = sanitizeUtm(ctx.utm_medium);
+    var campaign = sanitizeUtm(ctx.utm_campaign);
+    var host = ctx.referrer_host ? String(ctx.referrer_host).toLowerCase().slice(0, MAX_HOST_LEN) : '';
+    if (source) payload.utm_source = source;
+    if (medium) payload.utm_medium = medium;
+    if (campaign) payload.utm_campaign = campaign;
+    if (host && host.indexOf('..') === -1) payload.referrer_host = host;
+    if (ctx.dest_path) {
+      var dest = sanitizePath(ctx.dest_path);
+      if (dest) payload.dest_path = dest;
+    }
+    var allowed = {};
+    for (var i = 0; i < PAYLOAD_KEYS.length; i++) {
+      var k = PAYLOAD_KEYS[i];
+      if (Object.prototype.hasOwnProperty.call(payload, k) && payload[k] !== '' && payload[k] != null) {
+        allowed[k] = payload[k];
+      }
+    }
+    return allowed;
+  }
+
+  function shouldAnnotateJourneyLink(url) {
+    if (!url) return false;
+    var parsed = url;
+    if (typeof url === 'string') {
+      try { parsed = new URL(url, 'https://' + JOURNEY_HOST); } catch (err) { return false; }
+    }
+    var protocol = String(parsed.protocol || '').toLowerCase();
+    if (protocol !== 'http:' && protocol !== 'https:') return false;
+    return String(parsed.hostname || '').toLowerCase() === JOURNEY_HOST;
+  }
+
+  function normalizeHrefPath(url) {
+    var path = (url && url.pathname) ? url.pathname : '/';
+    return path.replace(/\/+$/, '') || '/';
+  }
+
+  function isConsultationCta(url, siteHost) {
+    if (!url) return false;
+    var parsed = url;
+    if (typeof url === 'string') {
+      try { parsed = new URL(url, 'https://' + (siteHost || 'hbexperts.com')); } catch (err) { return false; }
+    }
+    var protocol = String(parsed.protocol || '').toLowerCase();
+    if (protocol !== 'http:' && protocol !== 'https:') return false;
+    var host = String(parsed.hostname || '').toLowerCase();
+    if (siteHost && host && !sameSite(host, siteHost)) return false;
+    return !!CONSULTATION_PATHS[normalizeHrefPath(parsed)];
+  }
+
+  function annotateJourneyUrl(href, meta) {
+    meta = meta || {};
+    var url;
+    try {
+      url = new URL(String(href), 'https://' + JOURNEY_HOST);
+    } catch (err) {
+      return href;
+    }
+    if (!shouldAnnotateJourneyLink(url)) return href;
+    var ch = normalizeChannel(meta.channel);
+    var ft = normalizeChannel(meta.first_touch || meta.channel);
+    var lp = sanitizePath(meta.landing_path || meta.page_path || '/');
+    if (ch) url.searchParams.set('hbe_ch', ch);
+    if (lp) url.searchParams.set('hbe_lp', lp);
+    if (ft) url.searchParams.set('hbe_ft', ft);
+    return url.toString();
+  }
+
+  function readFirstTouch(storage) {
+    if (!storage || typeof storage.getItem !== 'function') return null;
+    try {
+      var raw = storage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      var parsed = JSON.parse(raw);
+      if (!parsed || parsed.v !== 1) return null;
+      parsed.channel = normalizeChannel(parsed.channel);
+      parsed.landing_path = sanitizePath(parsed.landing_path) || '/';
+      if (parsed.utm_source) parsed.utm_source = sanitizeUtm(parsed.utm_source);
+      if (parsed.utm_medium) parsed.utm_medium = sanitizeUtm(parsed.utm_medium);
+      if (parsed.utm_campaign) parsed.utm_campaign = sanitizeUtm(parsed.utm_campaign);
+      if (parsed.referrer_host) parsed.referrer_host = String(parsed.referrer_host).toLowerCase();
+      return parsed;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  function writeFirstTouch(storage, record) {
+    if (!storage || typeof storage.setItem !== 'function') return;
+    try {
+      storage.setItem(STORAGE_KEY, JSON.stringify(record));
+    } catch (err) { /* private mode / quota — do not break the page */ }
+  }
+
+  function pushRing(win, payload) {
+    if (!win) return;
+    var buf = win.__HBE_ACQ_EVENTS__;
+    if (!Array.isArray(buf)) buf = [];
+    buf.push(payload);
+    while (buf.length > MAX_EVENTS) buf.shift();
+    win.__HBE_ACQ_EVENTS__ = buf;
+  }
+
+  function cfTokenLooksSafe(token) {
+    var s = String(token || '').trim();
+    if (!s || s.length < 16 || s.length > 64) return '';
+    if (!/^[A-Za-z0-9_-]+$/.test(s)) return '';
+    return s;
+  }
+
+  function readCfToken(doc) {
+    if (!doc) return '';
+    try {
+      var meta = doc.querySelector && doc.querySelector('meta[name="hbe-cf-wa-token"]');
+      if (meta && meta.getAttribute) {
+        var fromMeta = cfTokenLooksSafe(meta.getAttribute('content'));
+        if (fromMeta) return fromMeta;
+      }
+      var el = doc.documentElement;
+      if (el && el.getAttribute) {
+        var fromData = cfTokenLooksSafe(el.getAttribute('data-cf-wa-token'));
+        if (fromData) return fromData;
+      }
+    } catch (err) { /* ignore */ }
+    return '';
+  }
+
+  function maybeLoadCfBeacon(doc, token) {
+    if (!doc || !token) return false;
+    try {
+      if (doc.querySelector && doc.querySelector('script[data-cf-beacon], script[src*="cloudflareinsights.com/beacon"]')) {
+        return false;
+      }
+      if (!doc.head || !doc.createElement) return false;
+      var s = doc.createElement('script');
+      s.defer = true;
+      s.src = 'https://static.cloudflareinsights.com/beacon.min.js';
+      s.setAttribute('data-cf-beacon', JSON.stringify({ token: token }));
+      doc.head.appendChild(s);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  function nowIso(clock) {
+    if (typeof clock === 'function') return clock();
+    return new Date().toISOString();
+  }
+
+  function createClient(env) {
+    env = env || {};
+    var win = env.window || (typeof window !== 'undefined' ? window : root);
+    var doc = env.document || (typeof document !== 'undefined' ? document : null);
+    var loc = env.location || (win && win.location) || null;
+    var storage = env.sessionStorage;
+    if (storage == null && win && win.sessionStorage) storage = win.sessionStorage;
+    var clock = env.now;
+
+    function emit(payload) {
+      pushRing(win, payload);
+      if (doc && typeof doc.dispatchEvent === 'function') {
+        try {
+          var Evt = (env.CustomEvent || (typeof CustomEvent !== 'undefined' ? CustomEvent : null));
+          if (Evt) doc.dispatchEvent(new Evt('hbe:acquisition', { detail: payload, bubbles: true }));
+        } catch (err) { /* ignore */ }
+      }
+      try {
+        var sink = win && win.__HBE_ACQ__;
+        if (sink && typeof sink.send === 'function') sink.send(payload);
+      } catch (err) { /* ignore */ }
+      return payload;
+    }
+
+    function currentContext() {
+      var search = (loc && loc.search) || '';
+      var path = pagePath((loc && loc.pathname) || '/');
+      var siteHost = (loc && loc.hostname) || '';
+      var utms = readUtms(search);
+      var ref = referrerHost(env.referrer != null ? env.referrer : (doc && doc.referrer) || '', siteHost);
+      var channel = classifyChannel(utms, ref);
+      var first = readFirstTouch(storage);
+      var weak = (channel === 'direct') || (channel === 'unknown' && !hasAnyUtm(utms) && !ref);
+      if (first && weak) channel = first.channel || channel;
+      if (!first) {
+        first = {
+          v: 1,
+          channel: channel,
+          landing_path: path,
+          ts: nowIso(clock)
+        };
+        if (utms.utm_source) first.utm_source = utms.utm_source;
+        if (utms.utm_medium) first.utm_medium = utms.utm_medium;
+        if (utms.utm_campaign) first.utm_campaign = utms.utm_campaign;
+        if (ref) first.referrer_host = ref;
+        writeFirstTouch(storage, first);
+      }
+      return {
+        page_path: path,
+        channel: channel,
+        utm_source: utms.utm_source,
+        utm_medium: utms.utm_medium,
+        utm_campaign: utms.utm_campaign,
+        referrer_host: ref,
+        first_touch: first,
+        siteHost: siteHost
+      };
+    }
+
+    function recordDiscoveryView() {
+      var ctx = currentContext();
+      return emit(buildPayload('discovery_view', {
+        page_path: ctx.page_path,
+        channel: ctx.channel,
+        utm_source: ctx.utm_source,
+        utm_medium: ctx.utm_medium,
+        utm_campaign: ctx.utm_campaign,
+        referrer_host: ctx.referrer_host,
+        ts: nowIso(clock)
+      }));
+    }
+
+    function handleAnchor(anchor) {
+      if (!anchor || !anchor.getAttribute) return;
+      var href = anchor.getAttribute('href');
+      if (!href) return;
+      var parsed;
+      try {
+        parsed = new URL(href, (loc && loc.href) || ('https://' + ((loc && loc.hostname) || 'hbexperts.com') + '/'));
+      } catch (err) {
+        return;
+      }
+      var ctx = currentContext();
+      var eventName = null;
+      if (shouldAnnotateJourneyLink(parsed)) {
+        eventName = 'journey_entry_click';
+        var annotated = annotateJourneyUrl(parsed.toString(), {
+          channel: ctx.channel,
+          first_touch: ctx.first_touch && ctx.first_touch.channel,
+          landing_path: ctx.first_touch && ctx.first_touch.landing_path,
+          page_path: ctx.page_path
+        });
+        try { anchor.href = annotated; } catch (err) { /* ignore */ }
+      } else if (isConsultationCta(parsed, ctx.siteHost)) {
+        eventName = 'consultation_cta_click';
+      }
+      if (!eventName) return;
+      emit(buildPayload(eventName, {
+        page_path: ctx.page_path,
+        channel: ctx.channel,
+        utm_source: ctx.utm_source,
+        utm_medium: ctx.utm_medium,
+        utm_campaign: ctx.utm_campaign,
+        referrer_host: ctx.referrer_host,
+        dest_path: parsed.pathname,
+        ts: nowIso(clock)
+      }));
+    }
+
+    function onClick(e) {
+      var t = e && e.target;
+      if (!t || typeof t.closest !== 'function') return;
+      var a = t.closest('a[href]');
+      if (a) handleAnchor(a);
+    }
+
+    function boot() {
+      if (win && !Array.isArray(win.__HBE_ACQ_EVENTS__)) win.__HBE_ACQ_EVENTS__ = [];
+      maybeLoadCfBeacon(doc, readCfToken(doc));
+      recordDiscoveryView();
+      if (doc && typeof doc.addEventListener === 'function') {
+        doc.addEventListener('click', onClick, false);
+      }
+    }
+
+    return {
+      boot: boot,
+      recordDiscoveryView: recordDiscoveryView,
+      handleAnchor: handleAnchor,
+      currentContext: currentContext,
+      emit: emit
+    };
+  }
+
+  var api = {
+    STORAGE_KEY: STORAGE_KEY,
+    MAX_EVENTS: MAX_EVENTS,
+    CHANNELS: CHANNELS,
+    PAYLOAD_KEYS: PAYLOAD_KEYS,
+    looksLikeEmail: looksLikeEmail,
+    looksLikePhone: looksLikePhone,
+    sanitizeUtm: sanitizeUtm,
+    sanitizePath: sanitizePath,
+    pagePath: pagePath,
+    referrerHost: referrerHost,
+    isSearchEngineHost: isSearchEngineHost,
+    classifyChannel: classifyChannel,
+    readUtms: readUtms,
+    buildPayload: buildPayload,
+    shouldAnnotateJourneyLink: shouldAnnotateJourneyLink,
+    isConsultationCta: isConsultationCta,
+    annotateJourneyUrl: annotateJourneyUrl,
+    readFirstTouch: readFirstTouch,
+    createClient: createClient,
+    boot: function (env) { return createClient(env).boot(); }
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+  root.HBEAcquisition = api;
+
+  var isBrowser = typeof document !== 'undefined' && typeof window !== 'undefined';
+  if (isBrowser && !root.__HBE_ACQ_NOAUTO__) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', function () { api.boot(); });
+    } else {
+      api.boot();
+    }
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/themes/hbe/static/js/acquisition.js
+++ b/themes/hbe/static/js/acquisition.js
@@ -1,9 +1,17 @@
 /**
- * HBE public-site acquisition measurement (first-party, privacy-safe).
+ * HBE public-site acquisition instrumentation foundation (first-party, privacy-safe).
  *
- * Records coarse discovery and CTA events only: pathname, channel, sanitized
- * UTM tokens, and referrer host. No names, emails, phones, questionnaire
- * answers, household IDs, cookies, or localStorage.
+ * This is a client-side instrumentation foundation, not completed acquisition
+ * measurement. Coarse discovery and CTA events (pathname, channel, sanitized
+ * UTM tokens, referrer host) stay session/in-memory only: CustomEvent
+ * `hbe:acquisition`, sessionStorage first-touch, and an in-memory ring buffer.
+ * No network collector ships here; a later gated collector may subscribe.
+ * Optional Cloudflare Web Analytics is a separate pageview product and does
+ * not receive these custom events.
+ *
+ * No names, emails, phones, questionnaire answers, household IDs, cookies,
+ * or localStorage. Journey URLs are left clean (no hbe_ch / hbe_lp / hbe_ft)
+ * until a secure-side consumer exists.
  *
  * Channel heuristics (see docs/ACQUISITION_MEASUREMENT.md):
  *   relocation / local — ONLY when utm_campaign or utm_content contains that
@@ -240,22 +248,10 @@
     return !!CONSULTATION_PATHS[normalizeHrefPath(parsed)];
   }
 
-  function annotateJourneyUrl(href, meta) {
-    meta = meta || {};
-    var url;
-    try {
-      url = new URL(String(href), 'https://' + JOURNEY_HOST);
-    } catch (err) {
-      return href;
-    }
-    if (!shouldAnnotateJourneyLink(url)) return href;
-    var ch = normalizeChannel(meta.channel);
-    var ft = normalizeChannel(meta.first_touch || meta.channel);
-    var lp = sanitizePath(meta.landing_path || meta.page_path || '/');
-    if (ch) url.searchParams.set('hbe_ch', ch);
-    if (lp) url.searchParams.set('hbe_lp', lp);
-    if (ft) url.searchParams.set('hbe_ft', ft);
-    return url.toString();
+  function annotateJourneyUrl(href) {
+    // No-op: leave buyer.hbexperts.com URLs clean until a secure-side
+    // consumer exists. Custom events stay session/in-memory only.
+    return href;
   }
 
   function readFirstTouch(storage) {
@@ -426,13 +422,6 @@
       var eventName = null;
       if (shouldAnnotateJourneyLink(parsed)) {
         eventName = 'journey_entry_click';
-        var annotated = annotateJourneyUrl(parsed.toString(), {
-          channel: ctx.channel,
-          first_touch: ctx.first_touch && ctx.first_touch.channel,
-          landing_path: ctx.first_touch && ctx.first_touch.landing_path,
-          page_path: ctx.page_path
-        });
-        try { anchor.href = annotated; } catch (err) { /* ignore */ }
       } else if (isConsultationCta(parsed, ctx.siteHost)) {
         eventName = 'consultation_cta_click';
       }

--- a/themes/hbe/static/js/acquisition.test.mjs
+++ b/themes/hbe/static/js/acquisition.test.mjs
@@ -105,8 +105,8 @@ test('classifyChannel: unknown leftover utm without paid/organic/referral signal
 test('sanitizeUtm drops email-like and phone-like values', () => {
   assert.equal(acq.sanitizeUtm('buyer@example.com'), '');
   assert.equal(acq.sanitizeUtm('Contact me@site.org today'), '');
-  assert.equal(acq.sanitizeUtm('330-328-3170'), '');
-  assert.equal(acq.sanitizeUtm('+1 (330) 328-3170'), '');
+  assert.equal(acq.sanitizeUtm('202-555-0100'), '');
+  assert.equal(acq.sanitizeUtm('+1 (202) 555-0100'), '');
   assert.equal(acq.sanitizeUtm('google'), 'google');
   assert.equal(acq.sanitizeUtm('  cpc  '), 'cpc');
 });
@@ -118,7 +118,7 @@ test('sanitizeUtm drops URL-like values and caps length', () => {
 });
 
 test('readUtms keeps only sanitized known keys', () => {
-  const utms = acq.readUtms('?utm_source=google&utm_medium=cpc&utm_campaign=buyer@x.com&utm_term=3303283170&utm_content=local&extra=nope');
+  const utms = acq.readUtms('?utm_source=google&utm_medium=cpc&utm_campaign=buyer@x.com&utm_term=2025550100&utm_content=local&extra=nope');
   assert.equal(utms.utm_source, 'google');
   assert.equal(utms.utm_medium, 'cpc');
   assert.equal(utms.utm_content, 'local');
@@ -177,7 +177,7 @@ test('shouldAnnotateJourneyLink only for buyer.hbexperts.com http(s)', () => {
   assert.equal(acq.shouldAnnotateJourneyLink('https://buyer.hbexperts.com/questionnaire'), true);
   assert.equal(acq.shouldAnnotateJourneyLink('https://hbexperts.com/strategy-session/'), false);
   assert.equal(acq.shouldAnnotateJourneyLink('mailto:buyers@hbexperts.com'), false);
-  assert.equal(acq.shouldAnnotateJourneyLink('tel:3303283170'), false);
+  assert.equal(acq.shouldAnnotateJourneyLink('tel:2025550100'), false);
 });
 
 test('annotateJourneyUrl leaves non-journey links unchanged', () => {

--- a/themes/hbe/static/js/acquisition.test.mjs
+++ b/themes/hbe/static/js/acquisition.test.mjs
@@ -154,22 +154,23 @@ test('discovery_view payload has no PII keys', () => {
   assert.equal(payload.household_id, undefined);
 });
 
-test('journey link annotation adds only coarse params', () => {
-  const href = acq.annotateJourneyUrl('https://buyer.hbexperts.com/questionnaire', {
+test('annotateJourneyUrl is a no-op and leaves journey URLs clean', () => {
+  const original = 'https://buyer.hbexperts.com/questionnaire';
+  const href = acq.annotateJourneyUrl(original, {
     channel: 'organic',
     first_touch: 'organic',
     landing_path: '/strategy-session/',
     email: 'buyer@example.com'
   });
+  assert.equal(href, original);
   const url = new URL(href);
   assert.equal(url.origin, 'https://buyer.hbexperts.com');
   assert.equal(url.pathname, '/questionnaire');
-  assert.equal(url.searchParams.get('hbe_ch'), 'organic');
-  assert.equal(url.searchParams.get('hbe_ft'), 'organic');
-  assert.equal(url.searchParams.get('hbe_lp'), '/strategy-session/');
+  assert.equal(url.searchParams.get('hbe_ch'), null);
+  assert.equal(url.searchParams.get('hbe_ft'), null);
+  assert.equal(url.searchParams.get('hbe_lp'), null);
   assert.equal(url.searchParams.get('email'), null);
-  assert.equal(url.searchParams.get('utm_term'), null);
-  assert.deepEqual([...url.searchParams.keys()].sort(), ['hbe_ch', 'hbe_ft', 'hbe_lp']);
+  assert.equal([...url.searchParams.keys()].length, 0);
 });
 
 test('shouldAnnotateJourneyLink only for buyer.hbexperts.com http(s)', () => {
@@ -228,7 +229,7 @@ test('client emits discovery_view, CustomEvent, ring buffer, and optional sink',
   assert.equal(stored.landing_path, '/');
 });
 
-test('journey click annotates href and fires journey_entry_click', () => {
+test('journey click fires journey_entry_click without mutating href', () => {
   const storage = memoryStorage();
   storage.setItem(acq.STORAGE_KEY, JSON.stringify({
     v: 1, channel: 'referral', landing_path: '/about/', ts: '2026-09-03T19:00:00.000Z', referrer_host: 'news.example.com'
@@ -244,14 +245,14 @@ test('journey click annotates href and fires journey_entry_click', () => {
     now: () => '2026-09-03T20:00:00.000Z',
     CustomEvent: FakeCustomEvent
   });
+  const originalHref = 'https://buyer.hbexperts.com/questionnaire';
   const anchor = {
-    href: 'https://buyer.hbexperts.com/questionnaire',
-    getAttribute(name) { return name === 'href' ? 'https://buyer.hbexperts.com/questionnaire' : null; }
+    href: originalHref,
+    getAttribute(name) { return name === 'href' ? originalHref : null; }
   };
   client.handleAnchor(anchor);
-  assert.match(anchor.href, /hbe_ch=referral/);
-  assert.match(anchor.href, /hbe_ft=referral/);
-  assert.match(anchor.href, /hbe_lp=%2Fabout%2F/);
+  assert.equal(anchor.href, originalHref);
+  assert.equal(new URL(anchor.href).search, '');
   assert.equal(win.__HBE_ACQ_EVENTS__.length, 1);
   const evt = win.__HBE_ACQ_EVENTS__[0];
   assert.equal(evt.event, 'journey_entry_click');

--- a/themes/hbe/static/js/acquisition.test.mjs
+++ b/themes/hbe/static/js/acquisition.test.mjs
@@ -1,0 +1,332 @@
+import { createRequire } from 'node:module';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+
+const require = createRequire(import.meta.url);
+const acq = require('./acquisition.js');
+
+const PII_KEYS = [
+  'email', 'phone', 'name', 'first_name', 'last_name', 'full_name',
+  'household', 'household_id', 'questionnaire', 'answers', 'ssn',
+  'address', 'buyer_id', 'utm_term', 'utm_content'
+];
+
+function memoryStorage() {
+  const map = new Map();
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => { map.set(k, String(v)); },
+    removeItem: (k) => { map.delete(k); },
+    _map: map
+  };
+}
+
+function fakeDocument() {
+  const emitter = new EventEmitter();
+  const headChildren = [];
+  const doc = {
+    referrer: '',
+    readyState: 'complete',
+    documentElement: { getAttribute: () => null },
+    head: {
+      appendChild(node) { headChildren.push(node); return node; }
+    },
+    createElement(tag) {
+      return { tagName: tag, defer: false, src: '', attrs: {}, setAttribute(k, v) { this.attrs[k] = v; } };
+    },
+    querySelector() { return null; },
+    addEventListener(type, fn) { emitter.on(type, fn); },
+    dispatchEvent(evt) { emitter.emit(evt.type, evt); return true; },
+    _headChildren: headChildren,
+    _emitter: emitter
+  };
+  return doc;
+}
+
+class FakeCustomEvent {
+  constructor(type, init) {
+    this.type = type;
+    this.detail = init && init.detail;
+    this.bubbles = !!(init && init.bubbles);
+  }
+}
+
+test('classifyChannel: paid from utm_medium', () => {
+  assert.equal(acq.classifyChannel({ utm_medium: 'cpc' }, ''), 'paid');
+  assert.equal(acq.classifyChannel({ utm_medium: 'ppc' }, ''), 'paid');
+  assert.equal(acq.classifyChannel({ utm_medium: 'paid_social' }, ''), 'paid');
+  assert.equal(acq.classifyChannel({ utm_medium: 'display' }, ''), 'paid');
+  assert.equal(acq.classifyChannel({ utm_medium: 'ads' }, ''), 'paid');
+});
+
+test('classifyChannel: paid from ad-platform utm_source', () => {
+  assert.equal(acq.classifyChannel({ utm_source: 'googleads' }, ''), 'paid');
+  assert.equal(acq.classifyChannel({ utm_source: 'fb' }, ''), 'paid');
+  assert.equal(acq.classifyChannel({ utm_source: 'meta' }, ''), 'paid');
+  assert.equal(acq.classifyChannel({ utm_source: 'bing' }, ''), 'paid');
+});
+
+test('classifyChannel: organic from search referrer or utm_medium', () => {
+  assert.equal(acq.classifyChannel({}, 'www.google.com'), 'organic');
+  assert.equal(acq.classifyChannel({}, 'www.google.co.uk'), 'organic');
+  assert.equal(acq.classifyChannel({}, 'www.bing.com'), 'organic');
+  assert.equal(acq.classifyChannel({}, 'duckduckgo.com'), 'organic');
+  assert.equal(acq.classifyChannel({ utm_medium: 'organic', utm_source: 'google' }, ''), 'organic');
+});
+
+test('classifyChannel: referral from external non-search host', () => {
+  assert.equal(acq.classifyChannel({}, 'news.example.com'), 'referral');
+  assert.equal(acq.classifyChannel({}, 'facebook.com'), 'referral');
+});
+
+test('classifyChannel: direct when no utm and no referrer', () => {
+  assert.equal(acq.classifyChannel({}, ''), 'direct');
+  assert.equal(acq.classifyChannel({}, null), 'direct');
+});
+
+test('classifyChannel: local and relocation only from explicit campaign tokens', () => {
+  assert.equal(acq.classifyChannel({ utm_campaign: 'local-awareness' }, ''), 'local');
+  assert.equal(acq.classifyChannel({ utm_content: 'local' }, 'www.google.com'), 'local');
+  assert.equal(acq.classifyChannel({ utm_campaign: 'relocation-neohio' }, ''), 'relocation');
+  assert.equal(acq.classifyChannel({ utm_content: 'relocation' , utm_medium: 'cpc' }, ''), 'relocation');
+  assert.equal(acq.classifyChannel({ utm_campaign: 'allocate-budget' }, ''), 'unknown');
+  assert.equal(acq.classifyChannel({ utm_campaign: 'locale-guide' }, ''), 'unknown');
+});
+
+test('classifyChannel: explicit local token precedes paid', () => {
+  assert.equal(acq.classifyChannel({ utm_medium: 'cpc', utm_campaign: 'local' }, ''), 'local');
+});
+
+test('classifyChannel: unknown leftover utm without paid/organic/referral signal', () => {
+  assert.equal(acq.classifyChannel({ utm_medium: 'email', utm_source: 'newsletter' }, ''), 'unknown');
+});
+
+test('sanitizeUtm drops email-like and phone-like values', () => {
+  assert.equal(acq.sanitizeUtm('buyer@example.com'), '');
+  assert.equal(acq.sanitizeUtm('Contact me@site.org today'), '');
+  assert.equal(acq.sanitizeUtm('330-328-3170'), '');
+  assert.equal(acq.sanitizeUtm('+1 (330) 328-3170'), '');
+  assert.equal(acq.sanitizeUtm('google'), 'google');
+  assert.equal(acq.sanitizeUtm('  cpc  '), 'cpc');
+});
+
+test('sanitizeUtm drops URL-like values and caps length', () => {
+  assert.equal(acq.sanitizeUtm('https://evil.example/path?x=1'), '');
+  const long = 'a'.repeat(80);
+  assert.equal(acq.sanitizeUtm(long).length, 64);
+});
+
+test('readUtms keeps only sanitized known keys', () => {
+  const utms = acq.readUtms('?utm_source=google&utm_medium=cpc&utm_campaign=buyer@x.com&utm_term=3303283170&utm_content=local&extra=nope');
+  assert.equal(utms.utm_source, 'google');
+  assert.equal(utms.utm_medium, 'cpc');
+  assert.equal(utms.utm_content, 'local');
+  assert.equal(utms.utm_campaign, undefined);
+  assert.equal(utms.utm_term, undefined);
+  assert.equal(utms.extra, undefined);
+});
+
+test('discovery_view payload has no PII keys', () => {
+  const payload = acq.buildPayload('discovery_view', {
+    page_path: '/strategy-session/?email=a@b.com',
+    channel: 'organic',
+    utm_source: 'google',
+    utm_medium: 'organic',
+    utm_campaign: 'buyer@example.com',
+    referrer_host: 'www.google.com',
+    ts: '2026-09-03T20:00:00.000Z',
+    email: 'should-not-copy',
+    household_id: 'nope'
+  });
+  assert.equal(payload.event, 'discovery_view');
+  assert.equal(payload.page_path, '/strategy-session/');
+  assert.equal(payload.channel, 'organic');
+  assert.equal(payload.utm_source, 'google');
+  assert.equal(payload.utm_medium, 'organic');
+  assert.equal(payload.referrer_host, 'www.google.com');
+  assert.equal(payload.utm_campaign, undefined);
+  for (const key of Object.keys(payload)) {
+    assert.equal(acq.PAYLOAD_KEYS.includes(key), true, 'unexpected key ' + key);
+    assert.equal(PII_KEYS.includes(key), false, 'pii key ' + key);
+  }
+  assert.equal(payload.email, undefined);
+  assert.equal(payload.household_id, undefined);
+});
+
+test('journey link annotation adds only coarse params', () => {
+  const href = acq.annotateJourneyUrl('https://buyer.hbexperts.com/questionnaire', {
+    channel: 'organic',
+    first_touch: 'organic',
+    landing_path: '/strategy-session/',
+    email: 'buyer@example.com'
+  });
+  const url = new URL(href);
+  assert.equal(url.origin, 'https://buyer.hbexperts.com');
+  assert.equal(url.pathname, '/questionnaire');
+  assert.equal(url.searchParams.get('hbe_ch'), 'organic');
+  assert.equal(url.searchParams.get('hbe_ft'), 'organic');
+  assert.equal(url.searchParams.get('hbe_lp'), '/strategy-session/');
+  assert.equal(url.searchParams.get('email'), null);
+  assert.equal(url.searchParams.get('utm_term'), null);
+  assert.deepEqual([...url.searchParams.keys()].sort(), ['hbe_ch', 'hbe_ft', 'hbe_lp']);
+});
+
+test('shouldAnnotateJourneyLink only for buyer.hbexperts.com http(s)', () => {
+  assert.equal(acq.shouldAnnotateJourneyLink('https://buyer.hbexperts.com/'), true);
+  assert.equal(acq.shouldAnnotateJourneyLink('https://buyer.hbexperts.com/questionnaire'), true);
+  assert.equal(acq.shouldAnnotateJourneyLink('https://hbexperts.com/strategy-session/'), false);
+  assert.equal(acq.shouldAnnotateJourneyLink('mailto:buyers@hbexperts.com'), false);
+  assert.equal(acq.shouldAnnotateJourneyLink('tel:3303283170'), false);
+});
+
+test('annotateJourneyUrl leaves non-journey links unchanged', () => {
+  const original = 'https://hbexperts.com/strategy-session/';
+  assert.equal(acq.annotateJourneyUrl(original, { channel: 'direct' }), original);
+});
+
+test('isConsultationCta matches public strategy-session and contact paths', () => {
+  assert.equal(acq.isConsultationCta('https://hbexperts.com/strategy-session/', 'hbexperts.com'), true);
+  assert.equal(acq.isConsultationCta('https://hbexperts.com/contact/', 'hbexperts.com'), true);
+  assert.equal(acq.isConsultationCta('https://hbexperts.com/about/', 'hbexperts.com'), false);
+  assert.equal(acq.isConsultationCta('https://buyer.hbexperts.com/', 'hbexperts.com'), false);
+});
+
+test('referrerHost keeps host only and strips same-site', () => {
+  assert.equal(acq.referrerHost('https://www.google.com/search?q=homebuyer+email@x.com', 'hbexperts.com'), 'www.google.com');
+  assert.equal(acq.referrerHost('https://hbexperts.com/about/?email=a@b.com', 'hbexperts.com'), '');
+  assert.equal(acq.referrerHost('https://www.hbexperts.com/', 'hbexperts.com'), '');
+});
+
+test('client emits discovery_view, CustomEvent, ring buffer, and optional sink', () => {
+  const storage = memoryStorage();
+  const doc = fakeDocument();
+  const win = { __HBE_ACQ_EVENTS__: [], __HBE_ACQ__: { send(p) { win._sent = (win._sent || []).concat([p]); } } };
+  const seen = [];
+  doc.addEventListener('hbe:acquisition', (evt) => seen.push(evt.detail));
+  const client = acq.createClient({
+    window: win,
+    document: doc,
+    location: { href: 'https://hbexperts.com/?utm_source=google&utm_medium=organic', pathname: '/', search: '?utm_source=google&utm_medium=organic', hostname: 'hbexperts.com' },
+    sessionStorage: storage,
+    referrer: 'https://www.google.com/search?q=secret',
+    now: () => '2026-09-03T20:00:00.000Z',
+    CustomEvent: FakeCustomEvent
+  });
+  client.boot();
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].event, 'discovery_view');
+  assert.equal(seen[0].channel, 'organic');
+  assert.equal(seen[0].page_path, '/');
+  assert.equal(seen[0].utm_source, 'google');
+  assert.equal(seen[0].referrer_host, 'www.google.com');
+  assert.equal(win.__HBE_ACQ_EVENTS__.length, 1);
+  assert.equal(win._sent.length, 1);
+  const stored = JSON.parse(storage.getItem(acq.STORAGE_KEY));
+  assert.equal(stored.v, 1);
+  assert.equal(stored.channel, 'organic');
+  assert.equal(stored.landing_path, '/');
+});
+
+test('journey click annotates href and fires journey_entry_click', () => {
+  const storage = memoryStorage();
+  storage.setItem(acq.STORAGE_KEY, JSON.stringify({
+    v: 1, channel: 'referral', landing_path: '/about/', ts: '2026-09-03T19:00:00.000Z', referrer_host: 'news.example.com'
+  }));
+  const doc = fakeDocument();
+  const win = { __HBE_ACQ_EVENTS__: [] };
+  const client = acq.createClient({
+    window: win,
+    document: doc,
+    location: { href: 'https://hbexperts.com/about/', pathname: '/about/', search: '', hostname: 'hbexperts.com' },
+    sessionStorage: storage,
+    referrer: 'https://hbexperts.com/',
+    now: () => '2026-09-03T20:00:00.000Z',
+    CustomEvent: FakeCustomEvent
+  });
+  const anchor = {
+    href: 'https://buyer.hbexperts.com/questionnaire',
+    getAttribute(name) { return name === 'href' ? 'https://buyer.hbexperts.com/questionnaire' : null; }
+  };
+  client.handleAnchor(anchor);
+  assert.match(anchor.href, /hbe_ch=referral/);
+  assert.match(anchor.href, /hbe_ft=referral/);
+  assert.match(anchor.href, /hbe_lp=%2Fabout%2F/);
+  assert.equal(win.__HBE_ACQ_EVENTS__.length, 1);
+  const evt = win.__HBE_ACQ_EVENTS__[0];
+  assert.equal(evt.event, 'journey_entry_click');
+  assert.equal(evt.dest_path, '/questionnaire');
+  assert.equal(evt.channel, 'referral');
+  assert.equal(evt.page_path, '/about/');
+  for (const key of Object.keys(evt)) {
+    assert.equal(PII_KEYS.includes(key), false, 'pii key ' + key);
+  }
+});
+
+test('consultation CTA fires consultation_cta_click without annotating', () => {
+  const storage = memoryStorage();
+  const doc = fakeDocument();
+  const win = { __HBE_ACQ_EVENTS__: [] };
+  const client = acq.createClient({
+    window: win,
+    document: doc,
+    location: { href: 'https://hbexperts.com/', pathname: '/', search: '', hostname: 'hbexperts.com' },
+    sessionStorage: storage,
+    referrer: '',
+    now: () => '2026-09-03T20:00:00.000Z',
+    CustomEvent: FakeCustomEvent
+  });
+  const href = 'https://hbexperts.com/strategy-session/';
+  const anchor = {
+    href,
+    getAttribute(name) { return name === 'href' ? href : null; }
+  };
+  client.handleAnchor(anchor);
+  assert.equal(anchor.href, href);
+  assert.equal(win.__HBE_ACQ_EVENTS__[0].event, 'consultation_cta_click');
+  assert.equal(win.__HBE_ACQ_EVENTS__[0].dest_path, '/strategy-session/');
+});
+
+test('first-touch is not overwritten on later internal navigation', () => {
+  const storage = memoryStorage();
+  const win = { __HBE_ACQ_EVENTS__: [] };
+  const first = acq.createClient({
+    window: win,
+    document: fakeDocument(),
+    location: { href: 'https://hbexperts.com/?utm_medium=cpc&utm_source=googleads', pathname: '/', search: '?utm_medium=cpc&utm_source=googleads', hostname: 'hbexperts.com' },
+    sessionStorage: storage,
+    referrer: '',
+    now: () => '2026-09-03T20:00:00.000Z',
+    CustomEvent: FakeCustomEvent
+  });
+  first.recordDiscoveryView();
+  assert.equal(JSON.parse(storage.getItem(acq.STORAGE_KEY)).channel, 'paid');
+  const later = acq.createClient({
+    window: win,
+    document: fakeDocument(),
+    location: { href: 'https://hbexperts.com/about/', pathname: '/about/', search: '', hostname: 'hbexperts.com' },
+    sessionStorage: storage,
+    referrer: 'https://hbexperts.com/',
+    now: () => '2026-09-03T20:01:00.000Z',
+    CustomEvent: FakeCustomEvent
+  });
+  const payload = later.recordDiscoveryView();
+  assert.equal(payload.channel, 'paid');
+  assert.equal(JSON.parse(storage.getItem(acq.STORAGE_KEY)).channel, 'paid');
+  assert.equal(JSON.parse(storage.getItem(acq.STORAGE_KEY)).landing_path, '/');
+});
+
+test('CF beacon stays off without a token', () => {
+  const doc = fakeDocument();
+  const client = acq.createClient({
+    window: { __HBE_ACQ_EVENTS__: [] },
+    document: doc,
+    location: { href: 'https://hbexperts.com/', pathname: '/', search: '', hostname: 'hbexperts.com' },
+    sessionStorage: memoryStorage(),
+    referrer: '',
+    now: () => '2026-09-03T20:00:00.000Z',
+    CustomEvent: FakeCustomEvent
+  });
+  client.boot();
+  assert.equal(doc._headChildren.length, 0);
+});


### PR DESCRIPTION
## Objective

Add a **privacy-safe instrumentation foundation** on the public informational site (coarse discovery and CTA events in-browser). This is **not** completed acquisition measurement. Events stay session/in-memory only until a later gated collector exists. Fixes #44.

Owner: ForgeRokBot.

## Current state

The public Hugo site (`themes/hbe`) had no analytics: `baseof.html` loaded only `nav.js`. There was no gtag, Plausible, Umami, or Cloudflare beacon. The privacy policy already allowed aggregate analytics if enabled and noted that GitHub Pages may log standard access data.

## Work completed

- First-party module `themes/hbe/static/js/acquisition.js` (public pages only) — **instrumentation foundation**:
  - Reads sanitized UTM tokens (`utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`) — short non-PII tokens only, max 64 chars; email/phone/URL-like values dropped.
  - Reads `document.referrer` **host only**.
  - Classifies coarse channel: `paid` | `referral` | `local` | `relocation` | `organic` | `direct` | `unknown`.
  - Persists first-touch in `sessionStorage` key `hbe_acq_v1` (session only). No `localStorage`. No tracking cookies.
  - Emits `CustomEvent` `hbe:acquisition` and keeps `window.__HBE_ACQ_EVENTS__` (max 20). These are **session/in-memory only**. No network collector ships in this PR; a later gated collector may subscribe.
- Journey clicks fire `journey_entry_click` **without mutating href**. `buyer.hbexperts.com` URLs stay clean: this module does **not** append `hbe_ch`, `hbe_lp`, or `hbe_ft` until a secure-side consumer exists. `annotateJourneyUrl` is a no-op.
- Wired after `nav.js` in `baseof.html`. Optional empty `cloudflareWebAnalyticsToken` in `hugo.toml`.
- Body `data-hbe-page` for `home` | `strategy` | `about` | `other`.
- Public docs: `docs/ACQUISITION_MEASUREMENT.md` (foundation framing).
- Privacy policy wording updated to match (session-only first-party events; optional CF WA is a **separate pageview product** and does not receive these custom events; off by default; no ad-targeting).
- Tests: `themes/hbe/static/js/acquisition.test.mjs` (`node --test`).

## Events / fields

| Event | When | Fields |
| --- | --- | --- |
| `discovery_view` | Public page `DOMContentLoaded` | `event`, `page_path` (pathname only), `channel`, optional sanitized `utm_source` / `utm_medium` / `utm_campaign`, optional `referrer_host`, `ts` |
| `journey_entry_click` | Click on `buyer.hbexperts.com` anchors | Same + `dest_path` (pathname only). Outbound URL is **not** annotated. |
| `consultation_cta_click` | Click on same-site `/strategy-session/` or `/contact/` | Same + `dest_path`. Not annotated. |

`utm_content` / `utm_term` may be read for classification only; they are not emitted. No names, emails, phones, questionnaire fields, or household IDs.

## Privacy rationale

This is an instrumentation foundation, not a measurement pipeline. Events are first-party, pathname- and channel-level, and session-scoped (CustomEvent + sessionStorage + ring buffer) until a later gated collector exists. Same-site referrers are ignored. Full referrer URLs are never stored. PII-like UTM values are dropped before storage or emission. The secure Buyer Journey at `buyer.hbexperts.com` is not instrumented from this public repo, and public-site links into it are left unmodified.

## Instrumented vs later / manual

**This PR (session/in-memory only):** public page views with coarse channel; clicks into the Buyer Journey (no URL mutation); clicks to Strategy Session / Contact.

**Optional / off by default / separate product:** Cloudflare Web Analytics (free, aggregate **pageviews**). It does **not** receive these custom events. Token is empty; CI needs no secrets.

**Hosting logs:** GitHub Pages may log standard access data. That is not this module.

**Out of scope:** a gated collector that stores or forwards these events; qualified Buyer Journey completion, questionnaire answers, household IDs, and portal behavior (secure platform). Spend, targets, and campaign sequencing are not documented here.

## How to enable optional Cloudflare Web Analytics

1. Create a Cloudflare Web Analytics site token (free).
2. Set `params.cloudflareWebAnalyticsToken` in `hugo.toml`.
3. Redeploy the public site. `baseof.html` injects the standard CF beacon only when the param is non-empty.

Leave empty to keep first-party-only instrumentation. CF Web Analytics still would not receive `hbe:acquisition` custom events. An optional test/collector sink `window.__HBE_ACQ__.send` is supported for a **later gated collector** but is not required and is not wired to a network destination here.

## Tests

```bash
node --test themes/hbe/static/js/acquisition.test.mjs
```

22 tests, 22 passed: channel classification (paid/organic/referral/direct/local/relocation), email/phone UTM drop, discovery_view key allowlist, journey URL no-op (no `hbe_*` params; clicks fire events without mutating href), CustomEvent / ring-buffer / sink smoke, first-touch persistence, CF beacon off by default.

The GitHub Pages homepage check currently requires `/js/nav.js` and allows additional scripts, so `acquisition.js` will not fail existing CI. A deploy.yml follow-up that has `workflow` scope can also run `node --test` and require `/js/acquisition.js` (this OAuth token cannot update GitHub Actions workflow files).

## What was not done

- Not merged. Not deployed. Order 2 not started. No paid sink.
- Did not reuse dual-build PRs 26/27.
- No new paid analytics/SEO product.
- No D1, HBEUI/BuyerUI auth, Cloudflare Access, MLS, sensitive-upload, or secure-platform privacy-boundary changes.
- No instrumentation of private portal pages.
- No copy of private-order strategy, targets, spend philosophy, or campaign sequencing.
