### PR TITLE
Northeast Ohio relocation hub (public)

### DIFF
--- a/content/buyer-representation.md
+++ b/content/buyer-representation.md
@@ -149,6 +149,14 @@ Before we begin viewing homes together, we explain the Buyer Value Agreement —
 
 ---
 
+## Relocating to Northeast Ohio?
+
+If you are moving into Summit, Stark, Medina, Wayne, or Cuyahoga Counties, start with the public relocation guide for practical considerations — without neighborhood rankings or unsupported claims.
+
+[Northeast Ohio relocation guide →]({{< relref "relocation" >}})
+
+---
+
 ## Explore before you decide
 
 You can see the entire Buyer Journey before giving HBE any personal information.

--- a/content/relocation.md
+++ b/content/relocation.md
@@ -1,0 +1,190 @@
+---
+title: "Moving to Northeast Ohio"
+subtitle: "A practical relocation guide for home buyers — decision framing without pressure, steering, or unsupported neighborhood claims."
+description: "How HomeBuyer Experts helps buyers relocating to Northeast Ohio understand regional considerations, explore options remotely, and protect buyer-only interests before choosing a home."
+jsonLd: true
+faq:
+  - question: "Can I explore the HBE process before sharing personal information?"
+    answer: "Yes. You can explore the full Buyer Journey at buyer.hbexperts.com before providing HBE any personal information."
+  - question: "Does HomeBuyer Experts represent sellers or list homes?"
+    answer: "No. HBE works only for home buyers, never represents the seller, and does not take listings."
+  - question: "Can relocating buyers work with HBE from out of town?"
+    answer: "Yes. Strategy conversations can happen by Zoom when in-person is not practical, and you can learn the process remotely before deciding whether representation fits."
+  - question: "What is a Buyer Strategy Session?"
+    answer: "It is a complimentary, no-obligation conversation of about one hour that uses VALUE to clarify goals, alternatives, tradeoffs, uncertainty, and evidence before urgency takes over."
+---
+
+## Relocating Is a Decision, Not Only a Search
+
+Moving to a new region adds distance, unfamiliar local rules, and more unknowns than a local purchase. Homes, municipalities, taxes, utilities, and daily logistics can differ across Northeast Ohio — and those differences matter more when you cannot casually drive neighborhoods every evening.
+
+HomeBuyer Experts (HBE) helps relocating buyers understand the decision they are making. We work **only for home buyers**, never for the seller, and we do not take listings. Our North Star is simple:
+
+> **What is best for the buyer?**
+
+That may mean buying. It may also mean changing the search, waiting, or not buying at all.
+
+You can [explore the Buyer Journey](https://buyer.hbexperts.com/) before sharing personal information with HBE.
+
+---
+
+## How HBE Serves Relocation Buyers
+
+### Buyer-only loyalty
+
+When you hire HBE under a buyer-agency agreement, our fiduciary loyalty is to you. We do not represent sellers and we do not list properties. Clear loyalty matters even more when you are learning a market from afar and cannot casually double-check every assumption yourself.
+
+[Learn how exclusive buyer representation works →]({{< relref "buyer-representation" >}})
+
+### Remote-capable process
+
+Distance does not have to mean rushing into a transaction. You can:
+
+- Explore the Buyer Journey online before sharing personal details
+- Use a complimentary [Buyer Strategy Session]({{< relref "strategy-session" >}}) by Zoom when in-person is not practical
+- Learn with VALUE — Values, Alternatives, Learning, Uncertainty, Evidence — so new facts can change the plan
+
+### Explore before you commit
+
+You do not need to register or share personal information to understand how HBE works. Start with the public Buyer Journey, then decide whether a Strategy Session or representation conversation is useful.
+
+[Explore the Buyer Journey →](https://buyer.hbexperts.com/)
+
+---
+
+## What to Understand Before Choosing Areas or Homes
+
+This page does **not** rank towns, recommend “best” neighborhoods, or quote unverified school, crime, price, tax-rate, or commute statistics. Those claims change, vary by address, and are easy to misuse. Instead, use the questions below — and objective third-party sources — to investigate what matters for *your* move.
+
+HBE’s Fair Housing commitment means we help buyers find objective information; we do not steer people toward or away from places based on protected characteristics. [Read our Fair Housing statement →]({{< relref "fair-housing" >}})
+
+### Regional differences (without ranking towns)
+
+HBE’s service area is described as Northeast Ohio: **Summit, Stark, Medina, Wayne & Cuyahoga Counties**. Within and across those counties, municipalities differ in services, rules, housing stock, and day-to-day logistics.
+
+Useful framing questions:
+
+- What daily life does this move need to support (work, family, care, recreation)?
+- Which differences between counties or municipalities would change your choice if you learned them early?
+- Are you comparing a few candidate areas for fit — or searching for a single “right” town?
+
+Avoid treating any community label as a substitute for property-level investigation.
+
+### Commute and “close enough”
+
+Commute tolerance is personal. Drive times change with route, time of day, weather, and mode of travel — so inventing minutes here would mislead.
+
+Ask yourself:
+
+- What does “close enough” mean for work, school routes you care about, airports, or family?
+- Which trips must be reliable on a bad-weather day?
+- Are you optimizing peak commute, total weekly travel, or something else?
+
+Treat published maps and your own timed trips (or trusted local observation) as evidence — not marketing claims.
+
+### Property taxes as a decision factor
+
+Property tax obligations vary by location and can affect monthly cost as much as mortgage principal and interest. Rates and assessments change; quoting a single number here would be unreliable.
+
+Investigate with primary sources such as the relevant **county auditor** (or equivalent local tax authority), property record cards, and recent tax bills for comparable properties — then revisit the total housing cost, not price alone.
+
+### Housing age, style, and inspections
+
+Much of Northeast Ohio’s housing stock is older. Age and construction style are not automatically good or bad — but they raise the importance of disciplined inspection and repair budgeting.
+
+Before emotional attachment hardens:
+
+- What systems (roof, foundation, electrical, plumbing, HVAC, windows) matter most for your risk tolerance?
+- Which findings would change price, terms, or willingness to proceed?
+- Who will evaluate the property when you cannot attend every visit in person?
+
+Evidence before commitment is part of how HBE works. [See VALUE →]({{< relref "value" >}})
+
+### Municipal differences, utilities, and HOAs
+
+Cities, villages, and townships can differ on services, permitting, utilities, and association rules. Treat these as investigation topics, not slogans:
+
+- Water, sewer, trash, and utility providers — municipal vs. private?
+- HOA or condo documents, fees, and restrictions that would affect your use of the home?
+- Local permitting expectations if you plan renovations?
+- Flood, drainage, or other site factors visible in public records and inspection work?
+
+### Learning from afar without pressure
+
+Remote buyers often feel pressure to decide quickly because travel is expensive and inventory moves. A better pattern:
+
+1. Clarify what the move must accomplish (values and constraints)
+2. Learn the process and your alternatives before urgency peaks
+3. Use structured remote conversations and documented findings
+4. Keep the option to wait, renegotiate, or walk away visible
+
+HBE’s role is to improve decision quality — not to manufacture urgency.
+
+---
+
+## Clear Buyer-Only Distinction
+
+| Many market experiences | HomeBuyer Experts |
+| --- | --- |
+| Brokerage may list homes or serve sellers | HBE works only for home buyers; no listings |
+| Access to properties can be mistaken for advocacy | Advocacy means loyalty, evidence, and protected decision quality |
+| Momentum can push toward closing | North Star: what is best for the buyer? |
+
+Finding homes is not the same as representation. Representation means understanding what matters to you, researching alternatives, surfacing risk and uncertainty, negotiating strategically, and protecting your leverage and confidentiality under a buyer-agency relationship.
+
+[Buyer representation overview →]({{< relref "buyer-representation" >}})
+
+---
+
+## Fair Housing
+
+Relocation advice must remain lawful and equal. HBE will not steer buyers toward or away from neighborhoods because of protected characteristics, and we will not use coded neighborhood language to signal a preferred type of resident.
+
+We will help you locate **objective third-party sources** when you want to research schools, public services, transportation, taxes, property records, or other community facts — and we will base search work on your stated, lawful, objective criteria.
+
+[Fair Housing commitment →]({{< relref "fair-housing" >}})
+
+---
+
+## A Sensible Next Step
+
+### Primary path — explore the Buyer Journey
+
+See the full process before sharing personal information with HBE.
+
+[Explore the Buyer Journey →](https://buyer.hbexperts.com/)
+
+### Secondary paths
+
+- [Schedule context: Buyer Strategy Session]({{< relref "strategy-session" >}}) — complimentary, no obligation, about one hour; Zoom available
+- [Exclusive buyer representation]({{< relref "buyer-representation" >}}) — how loyalty and advocacy work
+- [VALUE]({{< relref "value" >}}) — the decision-support framework used throughout the journey
+- [Contact]({{< relref "contact" >}}) — phone and email if you prefer a direct conversation
+
+---
+
+## FAQ for Relocating Buyers
+
+### Can I explore the HBE process before sharing personal information?
+
+Yes. You can explore the full Buyer Journey before providing HBE any personal information.
+
+[Explore the Buyer Journey →](https://buyer.hbexperts.com/)
+
+### Does HomeBuyer Experts represent sellers or list homes?
+
+No. HBE works only for home buyers, never represents the seller, and does not take listings.
+
+### Can relocating buyers work with HBE from out of town?
+
+Yes. Strategy conversations can happen by Zoom when in-person is not practical, and you can learn the process remotely before deciding whether representation fits.
+
+### What is a Buyer Strategy Session?
+
+It is a complimentary, no-obligation conversation of about one hour that uses VALUE to clarify goals, alternatives, tradeoffs, uncertainty, and evidence before urgency takes over.
+
+[Learn about the Strategy Session →]({{< relref "strategy-session" >}})
+
+### Will HBE tell me which neighborhood is “best”?
+
+No. We do not rank neighborhoods or steer housing choices. We help you define lawful, objective criteria and find third-party sources so **you** can evaluate fit.

--- a/content/relocation.md
+++ b/content/relocation.md
@@ -84,13 +84,13 @@ Treat published maps and your own timed trips (or trusted local observation) as 
 
 ### Property taxes as a decision factor
 
-Property tax obligations vary by location and can affect monthly cost as much as mortgage principal and interest. Rates and assessments change; quoting a single number here would be unreliable.
+Property taxes vary by location and can materially affect total monthly housing cost. Rates and assessments change; quoting a single number here would be unreliable.
 
 Investigate with primary sources such as the relevant **county auditor** (or equivalent local tax authority), property record cards, and recent tax bills for comparable properties — then revisit the total housing cost, not price alone.
 
 ### Housing age, style, and inspections
 
-Much of Northeast Ohio’s housing stock is older. Age and construction style are not automatically good or bad — but they raise the importance of disciplined inspection and repair budgeting.
+Many homes a relocating buyer encounters may have older systems or construction, so age and condition should be evaluated property by property. Age and construction style are not automatically good or bad — but they raise the importance of disciplined inspection and repair budgeting.
 
 Before emotional attachment hardens:
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -10,7 +10,7 @@ theme = "hbe"
   email = "buyers@hbexperts.com"
   location = "Northeast Ohio"
   counties = "Summit, Stark, Medina, Wayne & Cuyahoga Counties"
-  informationLastUpdated = "September 2, 2026"
+  informationLastUpdated = "September 3, 2026"
 
   # Optional. Cloudflare Web Analytics site token (free). Separate pageview product; does not receive first-party custom events. Leave empty to keep first-party-only instrumentation.
   cloudflareWebAnalyticsToken = ""
@@ -25,21 +25,25 @@ theme = "hbe"
     url = "/buyer-representation/"
     weight = 2
   [[menu.main]]
+    name = "Relocation"
+    url = "/relocation/"
+    weight = 3
+  [[menu.main]]
     name = "VALUE"
     url = "/value/"
-    weight = 3
+    weight = 4
   [[menu.main]]
     name = "Strategy Session"
     url = "/strategy-session/"
-    weight = 4
+    weight = 5
   [[menu.main]]
     name = "Explore the Journey"
     url = "https://buyer.hbexperts.com/"
-    weight = 5
+    weight = 6
   [[menu.main]]
     name = "Contact"
     url = "/contact/"
-    weight = 6
+    weight = 7
 
 [markup]
   [markup.goldmark]

--- a/tests/relocation-hub.test.mjs
+++ b/tests/relocation-hub.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * Relocation hub content guards (node-native, $0).
+ * Asserts Fair Housing posture, buyer-only language, Journey CTA,
+ * and absence of common steering / invented-stat phrasing.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const mdPath = join(root, 'content', 'relocation.md');
+const hugoPath = join(root, 'hugo.toml');
+const publicHtml = join(root, 'public', 'relocation', 'index.html');
+
+function read(path) {
+  return readFileSync(path, 'utf8');
+}
+
+test('relocation markdown exists', () => {
+  assert.equal(existsSync(mdPath), true, 'content/relocation.md must exist');
+});
+
+test('menu lists Relocation -> /relocation/', () => {
+  const hugo = read(hugoPath);
+  assert.match(hugo, /name\s*=\s*"Relocation"/);
+  assert.match(hugo, /url\s*=\s*"\/relocation\/"/);
+});
+
+test('buyer-only language and Journey CTA present in markdown', () => {
+  const md = read(mdPath);
+  assert.match(md, /works?\s+only\s+for\s+home\s+buyers/i);
+  assert.match(md, /never\s+(represent(s)?\s+the\s+seller|for the seller)/i);
+  assert.match(md, /https:\/\/buyer\.hbexperts\.com\//);
+  assert.match(md, /Explore the Buyer Journey/);
+});
+
+test('Fair Housing link present', () => {
+  const md = read(mdPath);
+  assert.match(md, /relref "fair-housing"|\/fair-housing\//);
+  assert.match(md, /Fair Housing/i);
+});
+
+test('covers required decision themes without thin city-page swarm', () => {
+  const md = read(mdPath);
+  for (const theme of [
+    /commute/i,
+    /property tax/i,
+    /inspect/i,
+    /HOA|municipal/i,
+    /remote/i,
+    /Summit,\s*Stark,\s*Medina,\s*Wayne/
+  ]) {
+    assert.match(md, theme);
+  }
+  // Prefer one hub: no swarm of city-named content files required by this feature
+  assert.equal(existsSync(join(root, 'content', 'akron.md')), false);
+  assert.equal(existsSync(join(root, 'content', 'cleveland.md')), false);
+});
+
+test('forbids common steering and unsupported claim phrases', () => {
+  const md = read(mdPath).toLowerCase();
+  const forbidden = [
+    'best neighborhood',
+    'best neighborhoods',
+    'safest neighborhood',
+    'top-rated school',
+    'school ranking',
+    'median home price',
+    'crime rate of',
+    'drive time of',
+    'tax rate of',
+    'millage rate'
+  ];
+  for (const phrase of forbidden) {
+    assert.equal(md.includes(phrase), false, `forbidden phrase present: ${phrase}`);
+  }
+});
+
+test('optional built HTML (if public/ exists) mirrors key assertions', () => {
+  if (!existsSync(publicHtml)) {
+    // Hugo build is optional for this unit check; skip quietly when not built.
+    return;
+  }
+  const html = read(publicHtml);
+  assert.match(html, /https:\/\/buyer\.hbexperts\.com\//);
+  assert.match(html, /fair-housing/i);
+  assert.match(html, /only for home buyers/i);
+  assert.equal(html.toLowerCase().includes('best neighborhood'), false);
+  if (html.includes('application/ld+json')) {
+    assert.match(html, /"@type":\s*"WebPage"/);
+    assert.doesNotMatch(html, /"@type":\s*"AggregateRating"/);
+  }
+});

--- a/themes/hbe/layouts/_default/baseof.html
+++ b/themes/hbe/layouts/_default/baseof.html
@@ -13,6 +13,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
+  {{ if .Params.jsonLd }}{{ partial "schema.html" . }}{{ end }}
   {{ with .Site.Params.cloudflareWebAnalyticsToken }}
   <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": {{ . | jsonify }}}'></script>
   {{ end }}

--- a/themes/hbe/layouts/index.html
+++ b/themes/hbe/layouts/index.html
@@ -126,7 +126,7 @@
     <div class="audience-grid">
       <div class="audience-card"><h3>First-Time Buyers</h3><p>Learn the process without being expected to know the right questions in advance.</p></div>
       <div class="audience-card"><h3>Growing Families</h3><p>Weigh how a home serves life today, what may change, and which tradeoffs matter most.</p></div>
-      <div class="audience-card"><h3>Relocating to NE Ohio</h3><p>Build local understanding and preserve decision quality even when distance limits firsthand knowledge.</p></div>
+      <div class="audience-card"><h3>Relocating to NE Ohio</h3><p>Build local understanding and preserve decision quality even when distance limits firsthand knowledge.</p><p><a href="{{ "relocation/" | relURL }}">Northeast Ohio relocation guide →</a></p></div>
       <div class="audience-card"><h3>Move-Up Buyers</h3><p>Coordinate equity, timing, alternatives, and transition risk without letting complexity dictate the choice.</p></div>
       <div class="audience-card"><h3>Downsizing</h3><p>Clarify what the next chapter actually needs before translating it into a property search.</p></div>
       <div class="audience-card"><h3>Investment Buyers</h3><p>Compare return, risk, market evidence, and opportunity cost with objective representation.</p></div>

--- a/themes/hbe/layouts/partials/schema.html
+++ b/themes/hbe/layouts/partials/schema.html
@@ -1,0 +1,47 @@
+{{- /* Minimal accurate WebPage / FAQPage JSON-LD when page opts in via params.jsonLd. No ratings/reviews. */ -}}
+{{- $permalink := .Permalink -}}
+{{- $desc := .Description | default .Site.Params.description -}}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": {{ .Title | jsonify }},
+  "description": {{ $desc | jsonify }},
+  "url": {{ $permalink | jsonify }},
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "HomeBuyer Experts",
+    "url": {{ .Site.BaseURL | jsonify }}
+  },
+  "about": {
+    "@type": "Thing",
+    "name": "Northeast Ohio home buyer relocation"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "HomeBuyer Experts",
+    "url": {{ .Site.BaseURL | jsonify }}
+  }
+}
+</script>
+{{- with .Params.faq }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {{- range $i, $item := . -}}
+    {{- if $i }},{{ end }}
+    {
+      "@type": "Question",
+      "name": {{ $item.question | jsonify }},
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": {{ $item.answer | jsonify }}
+      }
+    }
+    {{- end }}
+  ]
+}
+</script>
+{{- end }}


### PR DESCRIPTION
## Objective

Add a public, indexable Northeast Ohio relocation hub so relocating home buyers can understand practical decision factors and HBE’s buyer-only role **without registration**, then continue into the Buyer Journey.

Fixes #45.

## Buyer intent served

Relocation discovery: buyers considering a move into Northeast Ohio who need decision framing (process, remote buying, regional variation as questions) before sharing personal information.

## Sources / facts used (existing site only)

- Buyer-only posture; no listings; never represents the seller (`_index.md`, `buyer-representation.md`)
- Service area: Summit, Stark, Medina, Wayne & Cuyahoga Counties (`hugo.toml` params)
- VALUE framework; North Star “What is best for the buyer?”
- Explore Buyer Journey before sharing personal information (`https://buyer.hbexperts.com/`)
- Complimentary ~1 hour Strategy Session; Zoom available (`strategy-session.md`)
- Fiduciary loyalty under buyer-agency (`buyer-representation.md`)
- Fair Housing commitment and anti-steering posture (`fair-housing.md`)

## What the page covers

- How HBE serves relocation buyers (buyer-only loyalty; remote-capable process; explore before sharing)
- Practical considerations framed as investigation questions: regional/county-municipality variation (no town rankings), commute “close enough,” property taxes via county auditor / local sources, older housing stock → inspection importance, municipal/utilities/HOA differences, learning from afar without pressure
- Clear buyer-only distinction
- Primary CTA: Buyer Journey; secondary: Strategy Session, buyer representation, VALUE, contact
- Fair Housing link and explicit non-steering language
- Optional FAQ (process / remote / representation)
- Minimal accurate WebPage + FAQPage JSON-LD (no ratings/reviews schema)
- Main menu item **Relocation** → `/relocation/`
- Light discovery links from homepage “Relocating to NE Ohio” card and `buyer-representation.md`

## What was deliberately NOT claimed

- No tax rates, price medians, school rankings, crime stats, or commute minutes
- No “best neighborhood” persuasion or coded neighborhood recommendations
- No thin swarm of city pages
- No protected-class targeting

## Fair Housing posture

Aligned with `content/fair-housing.md`: help buyers find objective third-party sources; do not steer; base search on buyer’s stated lawful objective criteria.

## CTA / internal links

- Primary: `https://buyer.hbexperts.com/`
- Secondary: `/strategy-session/`, `/buyer-representation/`, `/value/`, `/contact/`
- Fair Housing: `/fair-housing/`
- Menu + homepage + buyer-representation discovery (minimal)

## Tests

- `node --test tests/relocation-hub.test.mjs` — asserts buyer-only language, Journey CTA, Fair Housing link, required themes, and absence of common steering / invented-stat phrases; optional HTML checks when `public/` is built
- Local Hugo smoke build: `/relocation/` exists, menu linked, Journey + Fair Housing present, no forbidden steering phrases, WebPage/FAQPage JSON-LD present

### Mobile / accessibility notes

- Uses existing `single.html` layout and site CSS (mobile nav / contrast unchanged)
- Semantic `h2`/`h3` headings in markdown; page `h1` from layout title
- Public → secure transition: outbound links to `buyer.hbexperts.com` for Journey exploration; no auth/D1/Access/MLS changes

## What was not done

- No merge, no deploy, no Worker publish
- No thin city-page SEO swarm
- No private keyword strategy, competitive analysis, conversion targets, outreach, forecasts, or private-epic notes in this PR
- No BuyerUI/HBEUI auth, D1, Access, MLS, or sensitive upload control changes
- No new paid SEO product

Owner: ForgeRokBot