### PR TITLE
Add Moving to Akron buyer guide

### DIFF
--- a/content/moving-to-akron.md
+++ b/content/moving-to-akron.md
@@ -1,0 +1,138 @@
+---
+title: "Moving to Akron: A Buyer’s Guide"
+subtitle: "Questions to investigate before choosing a home in Akron or nearby Summit County — without rankings, steering, or unsupported claims."
+description: "A practical Moving to Akron guide for home buyers: housing and inspections, property taxes, commute context, remote buying, and buyer-only representation with HomeBuyer Experts."
+jsonLd: true
+faq:
+  - question: "Does this guide rank Akron neighborhoods?"
+    answer: "No. HomeBuyer Experts does not rank neighborhoods or steer buyers. This guide frames questions and points to objective sources so you can evaluate fit for your own criteria."
+  - question: "Can I explore HBE before sharing personal information?"
+    answer: "Yes. You can explore the full Buyer Journey at buyer.hbexperts.com before providing HBE any personal information."
+  - question: "Does HomeBuyer Experts represent sellers in Akron?"
+    answer: "No. HBE works only for home buyers, never represents the seller, and does not take listings."
+  - question: "Where should I start if I am relocating to Northeast Ohio more broadly?"
+    answer: "Start with the Northeast Ohio relocation hub for regional framing, then use this Akron-focused guide for city- and property-level questions."
+---
+
+## Moving to Akron Is a Decision, Not a Ranking
+
+Akron sits in **Summit County**, within HomeBuyer Experts’ Northeast Ohio service area (Summit, Stark, Medina, Wayne, and Cuyahoga Counties). Buyers considering Akron often mix city neighborhoods, nearby suburbs, and other Summit County municipalities in one search — which makes clear questions more useful than slogans.
+
+This guide does **not** rank neighborhoods, recommend “best” streets, or quote unsourced school, safety, price, or “value” statistics. Those claims change, vary by address, and are easy to misuse. Instead, it frames what to investigate before you choose a home or location.
+
+HomeBuyer Experts (HBE) works **only for home buyers**, never for the seller, and does not take listings. Our North Star:
+
+> **What is best for the buyer?**
+
+That may mean buying in Akron, choosing another Summit County community, waiting, or not buying at all.
+
+- Regional framing: [Northeast Ohio relocation hub →]({{< relref "relocation" >}})
+- Process before personal details: [Explore the Buyer Journey →](https://buyer.hbexperts.com/)
+
+---
+
+## Housing Age, Styles, and Inspection Considerations
+
+Akron and nearby Summit County include a wide mix of housing ages and construction styles. Age and style are not automatically good or bad — but they raise the importance of property-level inspection and repair budgeting before emotional attachment hardens.
+
+Useful questions:
+
+- Which systems matter most for your risk tolerance (roof, foundation, electrical, plumbing, HVAC, windows, drainage)?
+- Which inspection findings would change price, terms, or willingness to proceed?
+- If you cannot attend every visit in person, who will evaluate the property and how will findings be documented for you?
+- Are you comparing total cost of ownership (repairs, utilities, insurance eligibility) — or purchase price alone?
+
+Treat each address as its own evidence file. A complementary regional discussion of housing age and inspections lives on the [relocation hub]({{< relref "relocation" >}}).
+
+---
+
+## Property Taxes and Municipal Differences (Source Carefully)
+
+Property taxes and municipal services can materially affect total monthly housing cost. Rates, assessments, and local rules **change** — so this page does not invent a single Akron tax figure.
+
+Investigate with primary sources and recent documents, then revisit total housing cost:
+
+- **Summit County auditor** (or the relevant county auditor if the property is outside Summit) — valuations, tax history, and property record cards
+- Recent tax bills for comparable properties you are seriously considering
+- City of Akron vs. other municipalities for services, permitting, utilities, and local rules that would affect *your* use of the home
+- HOA or condo documents, fees, and restrictions when applicable
+
+Ask: if taxes or municipal costs differed by a meaningful amount from your first assumption, would the home still fit?
+
+*Information on this page is decision framing, not a tax quote. Recheck primary sources near the date you make an offer. Site information last reviewed: September 2026.*
+
+---
+
+## Commute and Regional Context
+
+Akron’s place in Northeast Ohio matters for work, airports, family, and day trips — but published “minutes to X” claims are easy to get wrong. Drive times change with route, time of day, weather, and mode of travel.
+
+Frame the commute as your criteria, not a marketing number:
+
+- What does “close enough” mean for work, care responsibilities, airports, or family?
+- Which trips must stay reliable on a bad-weather day?
+- Are you optimizing peak commute, total weekly travel, or something else?
+- Does the search need to stay inside Akron city limits, or is Summit County (and nearby counties HBE serves) part of the real alternative set?
+
+Use maps, your own timed trips, and trusted local observation as evidence.
+
+---
+
+## Buying from Out of Town
+
+Remote and relocating buyers often feel pressure because travel is expensive and inventory moves. A steadier pattern:
+
+1. Clarify what the move must accomplish (values and constraints)
+2. Learn the process and alternatives before urgency peaks
+3. Use structured remote conversations and documented findings
+4. Keep wait, renegotiate, or walk-away options visible
+
+You can explore the [Buyer Journey](https://buyer.hbexperts.com/) before sharing personal information, and use a complimentary [Buyer Strategy Session]({{< relref "strategy-session" >}}) by Zoom when in-person is not practical.
+
+---
+
+## HBE’s Buyer-Only Role in Akron / Summit County
+
+When you hire HBE under a buyer-agency agreement, fiduciary loyalty is to you. We do not represent sellers and we do not list properties. Clear loyalty matters when you are learning a market from afar and cannot casually double-check every assumption yourself.
+
+[Exclusive buyer representation →]({{< relref "buyer-representation" >}})
+
+HBE’s Fair Housing commitment means we help buyers find objective information; we do not steer people toward or away from places based on protected characteristics. [Fair Housing statement →]({{< relref "fair-housing" >}})
+
+---
+
+## A Sensible Next Step
+
+### Primary path — explore the Buyer Journey
+
+See the full process before sharing personal information with HBE.
+
+[Explore the Buyer Journey →](https://buyer.hbexperts.com/)
+
+### Related public guides
+
+- [Northeast Ohio relocation hub →]({{< relref "relocation" >}}) — regional framing without neighborhood rankings
+- [Exclusive buyer representation →]({{< relref "buyer-representation" >}}) — loyalty, fiduciary duties, five-county service area
+- [Buyer Strategy Session →]({{< relref "strategy-session" >}}) — complimentary, no obligation; Zoom available
+- [VALUE →]({{< relref "value" >}}) — Values, Alternatives, Learning, Uncertainty, Evidence
+- [Contact →]({{< relref "contact" >}}) — if you prefer a direct conversation
+
+---
+
+## FAQ
+
+### Does this guide tell me which Akron neighborhood is best?
+
+No. HBE does not rank neighborhoods or steer housing choices. We help you define lawful, objective criteria and find third-party sources so **you** can evaluate fit.
+
+### Is Akron the only place HBE serves?
+
+No. HBE primarily serves Summit, Stark, Medina, Wayne, and Cuyahoga Counties. Akron is one city within that geography.
+
+### Can I read the regional relocation guide first?
+
+Yes. Start with the [Northeast Ohio relocation hub]({{< relref "relocation" >}}) for broader framing, then return here for Akron-focused questions.
+
+### Will exploring the Buyer Journey hire HBE as my agent?
+
+No. Exploring the Buyer Journey does not by itself create a buyer-agency relationship. HBE becomes your agent when you and HBE enter a written buyer-agency agreement.

--- a/content/moving-to-akron.md
+++ b/content/moving-to-akron.md
@@ -52,7 +52,7 @@ Property taxes and municipal services can materially affect total monthly housin
 
 Investigate with primary sources and recent documents, then revisit total housing cost:
 
-- **Summit County auditor** (or the relevant county auditor if the property is outside Summit) — valuations, tax history, and property record cards
+- **Summit County Fiscal Office — Property Tax & Appraisal** — valuations, tax history, and property record cards via the official county sites: [fiscaloffice.summitoh.net](https://fiscaloffice.summitoh.net/) and [propertyaccess.summitoh.net](https://propertyaccess.summitoh.net/). Summit County has warned about fraudulent lookalike “auditor” sites; prefer these authoritative links. If the property is outside Summit, use that county’s official fiscal/appraisal authority instead.
 - Recent tax bills for comparable properties you are seriously considering
 - City of Akron vs. other municipalities for services, permitting, utilities, and local rules that would affect *your* use of the home
 - HOA or condo documents, fees, and restrictions when applicable

--- a/content/relocation.md
+++ b/content/relocation.md
@@ -157,6 +157,7 @@ See the full process before sharing personal information with HBE.
 ### Secondary paths
 
 - [Schedule context: Buyer Strategy Session]({{< relref "strategy-session" >}}) — complimentary, no obligation, about one hour; Zoom available
+- [Moving to Akron buyer guide]({{< relref "moving-to-akron" >}}) — Akron / Summit County questions without rankings
 - [Exclusive buyer representation]({{< relref "buyer-representation" >}}) — how loyalty and advocacy work
 - [VALUE]({{< relref "value" >}}) — the decision-support framework used throughout the journey
 - [Contact]({{< relref "contact" >}}) — phone and email if you prefer a direct conversation


### PR DESCRIPTION
Closes #47.

## Summary
- Adds a public Moving to Akron buyer guide focused on questions buyers should investigate
- Covers housing age/styles and inspections, property-tax/municipal investigation (source/date-aware, no invented rates), commute framing, and remote-buying considerations
- Explains HBE buyer-only role; links to `/relocation/` and the Buyer Journey
- Adds a related link from the Northeast Ohio relocation hub
- Avoids neighborhood rankings, steering, and unsourced school/safety/value claims

## Verification
- Hugo 0.147.8 production build succeeded
- No secure-platform / auth / D1 / Access / MLS changes
- No Worker-publish; Pages deploy follows normal main merge later

Holding for Sentinel batch pass. Do not merge from this comment.