### PR TITLE
Connect public discovery pages to Buyer Journey

### DIFF
--- a/content/privacy.md
+++ b/content/privacy.md
@@ -20,7 +20,7 @@ The public HBE website can be browsed without completing the Buyer Experience.
 
 Inside the HBE Buyer Journey, you can explore the process before submitting personal information. A Buyer Experience draft may remain temporarily in your browser session so normal Back or Refresh actions do not erase your work. HBE does not intentionally create a buyer record from that draft until you deliberately submit it.
 
-When you choose **Submit to HBE**, you may provide information such as:
+When you deliberately **review and send** your Buyer Experience to HomeBuyer Experts, you may provide information such as:
 
 - Your name
 - Your email address

--- a/themes/hbe/layouts/_default/assessment.html
+++ b/themes/hbe/layouts/_default/assessment.html
@@ -10,7 +10,7 @@
       <div class="section-badge">Buyer-first by design</div>
       <h2>See the journey before you share anything.</h2>
       <p>The Buyer Experience now lives inside HBE's secure Buyer Journey. You can explore every stage first, understand what each step is for, and decide when — or whether — you want to begin.</p>
-      <p>Nothing personal is sent to HBE merely because you view the journey. Your Buyer Experience stays on your device until you deliberately press <strong>Submit to HBE</strong>.</p>
+      <p>Nothing personal is sent to HBE merely because you view the journey. Your Buyer Experience stays on your device until you deliberately <strong>review and send</strong> it to HomeBuyer Experts.</p>
       <p>We ask questions for one reason: to better understand what matters to you, how you make consequential decisions, and what could help you choose more wisely.</p>
       <div class="form-nav">
         <a class="btn btn-primary" href="https://buyer.hbexperts.com/" data-hbe-cta="buyer-journey">Explore the Buyer Journey</a>

--- a/themes/hbe/layouts/_default/assessment.html
+++ b/themes/hbe/layouts/_default/assessment.html
@@ -13,7 +13,7 @@
       <p>Nothing personal is sent to HBE merely because you view the journey. Your Buyer Experience stays on your device until you deliberately press <strong>Submit to HBE</strong>.</p>
       <p>We ask questions for one reason: to better understand what matters to you, how you make consequential decisions, and what could help you choose more wisely.</p>
       <div class="form-nav">
-        <a class="btn btn-primary" href="https://buyer.hbexperts.com/">Explore the Buyer Journey</a>
+        <a class="btn btn-primary" href="https://buyer.hbexperts.com/" data-hbe-cta="buyer-journey">Explore the Buyer Journey</a>
         <a class="btn btn-secondary" href="{{ "strategy-session/" | relURL }}">Learn About the Strategy Session</a>
       </div>
     </div>

--- a/themes/hbe/layouts/index.html
+++ b/themes/hbe/layouts/index.html
@@ -6,7 +6,7 @@
     <p class="hero-tagline">{{ .Site.Params.tagline }}</p>
     <div class="hero-cta">
       <a href="{{ "value/" | relURL }}" class="btn btn-secondary">See How VALUE Works</a>
-      <a href="https://buyer.hbexperts.com/" class="btn btn-primary">Explore the Buyer Journey</a>
+      <a href="https://buyer.hbexperts.com/" class="btn btn-primary" data-hbe-cta="buyer-journey">Explore the Buyer Journey</a>
     </div>
   </div>
 </section>
@@ -153,8 +153,7 @@
 
 <section class="cta-section">
   <h2>Start by Understanding the Decision</h2>
-  <p>Explore the full Buyer Journey first. You can see the process before sharing anything with HBE.</p>
-  <a href="https://buyer.hbexperts.com/" class="btn btn-primary btn-large">Explore the Buyer Journey</a>
+  {{ partial "journey-cta.html" (dict "class" "btn btn-primary btn-large") }}
   <p style="margin-top: 1.5rem; font-size: 0.95rem;">Or start a conversation: <a href="tel:{{ .Site.Params.phone }}" style="font-weight: 600;">{{ .Site.Params.phone }}</a></p>
 </section>
 {{ end }}

--- a/themes/hbe/layouts/partials/header.html
+++ b/themes/hbe/layouts/partials/header.html
@@ -10,7 +10,7 @@
       {{ range .Site.Menus.main }}
       <li><a href="{{ .URL | relURL }}"{{ if $.IsMenuCurrent "main" . }} class="active"{{ end }}>{{ .Name }}</a></li>
       {{ end }}
-      <li class="nav-cta"><a href="https://buyer.hbexperts.com/questionnaire" style="white-space: nowrap;">Start Buyer Experience</a></li>
+      <li class="nav-cta"><a href="https://buyer.hbexperts.com/" style="white-space: nowrap;" data-hbe-cta="buyer-journey">Explore the Buyer Journey</a></li>
     </ul>
   </nav>
 </header>

--- a/themes/hbe/layouts/partials/journey-cta.html
+++ b/themes/hbe/layouts/partials/journey-cta.html
@@ -1,0 +1,14 @@
+{{/*
+  Consistent public CTA into the secure Buyer Journey.
+  Primary destination is always buyer.hbexperts.com/ (explore first).
+  Do not deep-link public discovery CTAs into /questionnaire, /portal, or /hbe.
+*/}}
+{{- $label := .label | default "Explore the Buyer Journey" -}}
+{{- $class := .class | default "btn btn-primary" -}}
+{{- $showExplain := ne .explain false -}}
+<div class="journey-cta">
+  {{- if $showExplain }}
+  <p class="journey-cta-explain">After you click, you leave this public site and open HBE’s secure Buyer Journey. You can explore every stage before sharing personal information. Nothing is submitted to HBE until you deliberately review and send a Buyer Experience from that Journey.</p>
+  {{- end }}
+  <p class="journey-cta-actions"><a href="https://buyer.hbexperts.com/" class="{{ $class }}" data-hbe-cta="buyer-journey">{{ $label }}</a></p>
+</div>

--- a/themes/hbe/static/css/style.css
+++ b/themes/hbe/static/css/style.css
@@ -966,3 +966,14 @@ hr { border: none; border-top: 1px solid var(--color-border); margin: 3rem 0; }
 .footer-links a:hover {
   color: rgba(255,255,255,0.9);
 }
+
+/* Public discovery → Buyer Journey CTA */
+.journey-cta-explain {
+  max-width: 36rem;
+  margin: 0 auto 1rem;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  opacity: 0.92;
+}
+.cta-section .journey-cta-explain { color: inherit; }
+.journey-cta-actions { margin: 0; }

--- a/themes/hbe/static/js/journey-cta.test.mjs
+++ b/themes/hbe/static/js/journey-cta.test.mjs
@@ -30,4 +30,15 @@ test('public layouts use one Journey host CTA and do not deep-link private surfa
   assert.match(partial, /After you click/);
   assert.match(partial, /before sharing personal information/);
   assert.match(partial, /deliberately review and send/);
+  assert.doesNotMatch(joined, /Submit to HBE/);
+});
+
+test('public privacy and assessment copy use review-and-send verbs', () => {
+  const root = join(themeRoot, '../..');
+  const privacy = readFileSync(join(root, 'content/privacy.md'), 'utf8');
+  const assessment = readFileSync(join(layoutsRoot, '_default/assessment.html'), 'utf8');
+  assert.doesNotMatch(privacy, /Submit to HBE/);
+  assert.match(privacy, /review and send/i);
+  assert.doesNotMatch(assessment, /Submit to HBE/);
+  assert.match(assessment, /review and send/i);
 });

--- a/themes/hbe/static/js/journey-cta.test.mjs
+++ b/themes/hbe/static/js/journey-cta.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const themeRoot = join(dirname(fileURLToPath(import.meta.url)), '../..');
+const layoutsRoot = join(themeRoot, 'layouts');
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, name.name);
+    if (name.isDirectory()) walk(p, out);
+    else if (/\.(html|md)$/.test(name.name)) out.push(p);
+  }
+  return out;
+}
+
+test('public layouts use one Journey host CTA and do not deep-link private surfaces', () => {
+  const files = walk(layoutsRoot);
+  const joined = files.map(f => readFileSync(f, 'utf8')).join('\n');
+  assert.match(joined, /https:\/\/buyer\.hbexperts\.com\/"/);
+  assert.doesNotMatch(joined, /buyer\.hbexperts\.com\/questionnaire/);
+  assert.doesNotMatch(joined, /buyer\.hbexperts\.com\/portal/);
+  assert.doesNotMatch(joined, /buyer\.hbexperts\.com\/hbe/);
+  const header = readFileSync(join(layoutsRoot, 'partials/header.html'), 'utf8');
+  assert.match(header, /Explore the Buyer Journey/);
+  assert.match(header, /https:\/\/buyer\.hbexperts\.com\/"/);
+  const partial = readFileSync(join(layoutsRoot, 'partials/journey-cta.html'), 'utf8');
+  assert.match(partial, /After you click/);
+  assert.match(partial, /before sharing personal information/);
+  assert.match(partial, /deliberately review and send/);
+});


### PR DESCRIPTION
Closes #48

## Summary
- One consistent primary CTA to `buyer.hbexperts.com/` (explore first).
- Nav no longer deep-links `/questionnaire`.
- Home CTA explains what happens after click.
- No auth/D1/Access/MLS changes; Journey URLs stay clean for privacy-safe attribution.

## Hold
Holding for Sentinel review. Do not merge.