### PR TITLE
fix(questionnaire): keep orientation cards on page 1 only (#48)

### DIFF
--- a/secure-platform/src/issue33-production-worker.js
+++ b/secure-platform/src/issue33-production-worker.js
@@ -9,6 +9,7 @@ export const BUYER_FIRST_CSS = `<style id="buyer-first-clarity">
 .buyer-answer-help{display:block;margin:.4rem 0 .15rem;color:#5f625f;font-size:.86rem;line-height:1.45}.buyer-answer-help strong{color:#2d5a3d}.buyer-suggestions{display:flex;flex-wrap:wrap;gap:.4rem;margin:.45rem 0 .7rem}.buyer-suggestion{appearance:none;border:1px solid #cad8ce;background:#fff;color:#2d5a3d;border-radius:999px;padding:.38rem .62rem;font:inherit;font-size:.8rem;font-weight:700;cursor:pointer}.buyer-suggestion:hover,.buyer-suggestion:focus-visible{background:#edf6f0;outline:2px solid rgba(45,90,61,.24);outline-offset:1px}
 .buyer-focus-card{background:#fff;border:1px solid #dfe8e2;border-radius:14px;padding:1.2rem 1.25rem;margin:1rem 0 1.15rem;box-shadow:0 8px 26px rgba(26,26,46,.05)}.buyer-focus-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:.7rem;margin-top:.9rem}.buyer-focus-grid>div{background:#faf9f6;border-radius:10px;padding:.8rem}.buyer-focus-grid small{display:block;color:#6b6b6b;font-size:.68rem;font-weight:900;letter-spacing:.08em;text-transform:uppercase;margin-bottom:.2rem}.buyer-focus-grid strong{color:#1a1a2e;line-height:1.35}.buyer-focus-card h1{font:600 clamp(1.5rem,4vw,2.05rem) Georgia,serif;color:#1a1a2e;margin:.2rem 0}.buyer-focus-card p{margin:.35rem 0;color:#555;line-height:1.5}.buyer-more{background:#fff;border:1px solid #e8e5e0;border-radius:12px;margin:.8rem 0;overflow:hidden}.buyer-more>summary{cursor:pointer;padding:1rem 1.05rem;font-weight:850;color:#1a1a2e;list-style:none}.buyer-more>summary::-webkit-details-marker{display:none}.buyer-more>summary:after{content:'+';float:right;color:#2d5a3d;font-size:1.2rem}.buyer-more[open]>summary:after{content:'–'}.buyer-more-body{padding:0 1rem 1rem}.buyer-focus-card+.i29-next{margin-top:0}.buyer-focus-card+.i29-next h2{font-size:1.05rem}.buyer-focus-card+.i29-next>strong{font-size:1.35rem}.buyer-focus-card+.i29-next .i29-tasks{display:none}
 @media(max-width:760px){.buyer-focus-grid{grid-template-columns:1fr 1fr}}@media(max-width:600px){.buyer-review{padding:1rem}.buyer-review-actions{display:grid;grid-template-columns:1fr}.buyer-review-actions button{width:100%}.buyer-focus-grid{grid-template-columns:1fr}.buyer-focus-card{padding:1rem}}
+.qx-page1-orient{margin:0 0 1rem}.step .buyer-first-core.qx-page1-orient{max-width:none;margin:0 0 1rem}.step .value-context.qx-page1-orient{max-width:none;margin:0 0 .85rem}.step .i29-comp.qx-page1-orient{margin:0 0 1.15rem}
 </style>`;
 
 export const BUYER_FIRST_JS = `<script id="buyer-first-review-script">
@@ -119,6 +120,54 @@ export function addBuyerFirstClarity(text, pathname) {
   return text;
 }
 
+
+/**
+ * Move orientation education cards into questionnaire page 1 only.
+ * Cards currently injected after <main> / before </main> stay visible on every
+ * multi-step Continue; confining them to the first .step hides them on pages 2–8.
+ * Idempotent: safe if already confined or if form/steps are missing.
+ */
+export function confineOrientationCardsToPage1(text) {
+  if (!text || typeof text !== 'string') return text;
+
+  const extracted = [];
+
+  const take = (re) => {
+    const match = text.match(re);
+    if (!match) return null;
+    text = text.replace(match[0], '');
+    return match[0];
+  };
+
+  // Public VALUE line only (not portal/HBE panels).
+  const value = take(/<div\b(?=[^>]*\bclass="[^"]*\bvalue-context\b)(?![^>]*\bvalue-portal-panel\b)[^>]*>[\s\S]*?<\/div>/i);
+  const buyer = take(/<div\b(?=[^>]*\bclass="[^"]*\bbuyer-first-core\b)[^>]*>[\s\S]*?<\/div>/i);
+  const comp = take(/<section\b(?=[^>]*\bid="compensation-note")[^>]*>[\s\S]*?<\/section>/i);
+
+  // Preferred keep order: buyer-first → VALUE → compensation
+  if (buyer) extracted.push(ensureQxOrientClass(buyer));
+  if (value) extracted.push(ensureQxOrientClass(value));
+  if (comp) extracted.push(ensureQxOrientClass(comp));
+
+  if (!extracted.length) return text;
+
+  const block = extracted.join('');
+  const stepOpen = text.match(/<section\b[^>]*\bclass="[^"]*\bstep\b[^"]*"[^>]*>/i);
+  if (!stepOpen) {
+    // Graceful fallback: restore near <main> so cards are not deleted.
+    if (text.includes('<main')) return text.replace(/(<main[^>]*>)/i, `$1${block}`);
+    return text.replace(/<body([^>]*)>/i, `<body$1>${block}`);
+  }
+
+  // Extract-then-reinject is idempotent even when cards were already inside page 1.
+  return text.replace(stepOpen[0], `${stepOpen[0]}${block}`);
+}
+
+function ensureQxOrientClass(html) {
+  if (/\bqx-page1-orient\b/.test(html)) return html;
+  return html.replace(/\bclass="([^"]*)"/i, 'class="$1 qx-page1-orient"');
+}
+
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
@@ -168,6 +217,9 @@ export default {
 
     if (request.method === 'GET' && response.status === 200) {
       text = addBuyerFirstClarity(text, url.pathname);
+      if (url.pathname === '/questionnaire') {
+        text = confineOrientationCardsToPage1(text);
+      }
     }
 
     if (!text.includes('id="issue33-bimatrix-css"')) {

--- a/secure-platform/tests/issue48-page1-orient.test.mjs
+++ b/secure-platform/tests/issue48-page1-orient.test.mjs
@@ -1,0 +1,184 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { addBuyerFirstClarity, confineOrientationCardsToPage1 } from '../src/issue33-production-worker.js';
+import { compensationPublicHtml } from '../src/issue29-ui.js';
+
+const VALUE_LINE =
+  '<div class="value-context"><strong>VALUE</strong><span>Values · Alternatives · Learning · Uncertainty · Evidence</span></div>';
+
+const BUYER_CORE =
+  '<div class="buyer-first-core" role="note"><strong>HomeBuyer Experts helps people buy homes.</strong> We work only for home buyers — never for the seller. Our job is to help you make the best choice for you, even when the best choice is to walk away.</div>';
+
+function syntheticQuestionnaire() {
+  return `<!doctype html><html><head></head><body><main class="experience">
+${BUYER_CORE}
+${VALUE_LINE}
+<div class="progress-row"><span>1 of 8</span></div>
+<form id="buyerExperienceForm" method="post" action="/api/intake">
+<section class="step active" data-title="You & this decision">
+<div class="eyebrow">Part 1</div><h1>Start with you.</h1>
+<p class="intro">Page 1 intro stays.</p>
+<div class="privacy">Nothing is sent yet.</div>
+<div class="navrow"><button type="button">Continue</button></div>
+</section>
+<section class="step" data-title="What matters">
+<div class="eyebrow">Part 2</div><h1>What matters</h1>
+<p class="intro">Page 2 intro stays.</p>
+<div class="navrow"><button type="button">Back</button><button type="button">Continue</button></div>
+</section>
+<section class="step" data-title="How you decide">
+<div class="eyebrow">Part 3</div><h1>How you decide</h1>
+<div class="navrow"><button type="button">Back</button><button type="button">Continue</button></div>
+</section>
+<section class="step" data-title="Pressure">
+<div class="eyebrow">Part 4</div><h1>Pressure</h1>
+</section>
+<section class="step" data-title="Others">
+<div class="eyebrow">Part 5</div><h1>Others</h1>
+</section>
+<section class="step" data-title="Life">
+<div class="eyebrow">Part 6</div><h1>Life</h1>
+</section>
+<section class="step" data-title="Practical">
+<div class="eyebrow">Part 7</div><h1>Practical</h1>
+</section>
+<section class="step" data-title="Success">
+<div class="eyebrow">Part 8</div><h1>Success</h1>
+</section>
+</form>
+${compensationPublicHtml()}
+</main></body></html>`;
+}
+
+function steps(html) {
+  const parts = [];
+  const re = /<section\b([^>]*)\bclass="([^"]*\bstep\b[^"]*)"([^>]*)>([\s\S]*?)<\/section>/gi;
+  // Depth-aware split: first find each step open, then walk to matching close
+  const openRe = /<section\b[^>]*\bclass="[^"]*\bstep\b[^"]*"[^>]*>/gi;
+  let match;
+  const opens = [];
+  while ((match = openRe.exec(html))) opens.push({ index: match.index, open: match[0], end: match.index + match[0].length });
+  for (let i = 0; i < opens.length; i++) {
+    const start = opens[i].end;
+    const limit = i + 1 < opens.length ? opens[i + 1].index : html.length;
+    // From start, find the step's own closing </section> with depth (compensation nests a section)
+    let depth = 1;
+    const tagRe = /<\/?section\b[^>]*>/gi;
+    tagRe.lastIndex = start;
+    let closeAt = -1;
+    let m;
+    while ((m = tagRe.exec(html)) && m.index < html.length) {
+      if (m[0].startsWith('</')) depth -= 1;
+      else depth += 1;
+      if (depth === 0) {
+        closeAt = m.index;
+        break;
+      }
+      if (i + 1 < opens.length && m.index >= opens[i + 1].index && depth === 1) {
+        // reached next sibling step open while still inside — shouldn't happen
+        break;
+      }
+    }
+    const body = closeAt >= 0 ? html.slice(start, closeAt) : html.slice(start, limit);
+    parts.push({ open: opens[i].open, body, full: opens[i].open + body });
+  }
+  return parts;
+}
+
+test('confine puts buyer-first, VALUE, and compensation inside first .step only', () => {
+  const html = confineOrientationCardsToPage1(syntheticQuestionnaire());
+  const all = steps(html);
+  assert.equal(all.length, 8);
+
+  const first = all[0].body;
+  assert.match(first, /buyer-first-core/);
+  assert.match(first, /value-context/);
+  assert.match(first, /id="compensation-note"/);
+  assert.match(first, /qx-page1-orient/);
+
+  // Order: buyer-first → VALUE → compensation
+  const iBuyer = first.indexOf('buyer-first-core');
+  const iValue = first.indexOf('value-context');
+  const iComp = first.indexOf('compensation-note');
+  assert.ok(iBuyer >= 0 && iValue > iBuyer && iComp > iValue);
+
+  for (let i = 1; i < all.length; i++) {
+    assert.doesNotMatch(all[i].body, /buyer-first-core/);
+    assert.doesNotMatch(all[i].body, /value-context/);
+    assert.doesNotMatch(all[i].body, /compensation-note/);
+    assert.doesNotMatch(all[i].body, /qx-page1-orient/);
+  }
+
+  // Still present once (not deleted)
+  assert.equal((html.match(/buyer-first-core/g) || []).length, 1);
+  assert.equal((html.match(/class="value-context/g) || []).length, 1);
+  assert.equal((html.match(/id="compensation-note"/g) || []).length, 1);
+
+  // Page chrome preserved
+  assert.match(html, /1 of 8/);
+  assert.match(html, /Page 1 intro stays/);
+  assert.match(html, /Page 2 intro stays/);
+  assert.match(html, /Nothing is sent yet/);
+});
+
+test('confine is idempotent when already page-1 confined', () => {
+  const once = confineOrientationCardsToPage1(syntheticQuestionnaire());
+  const twice = confineOrientationCardsToPage1(once);
+  assert.equal(twice, once);
+});
+
+test('addBuyerFirstClarity keeps homepage buyer-first at main level (not page1-confined)', () => {
+  const home = '<!doctype html><html><head></head><body><main><h1>Journey</h1></main></body></html>';
+  const html = addBuyerFirstClarity(home, '/');
+  assert.match(html, /buyer-first-core/);
+  assert.match(html, /<main[^>]*>\s*<div class="buyer-first-core"/);
+  // Orient class may appear in shared CSS; the card itself must stay unconfined on /.
+  assert.doesNotMatch(html, /class="buyer-first-core[^"]*qx-page1-orient/);
+  assert.doesNotMatch(html, /class="[^"]*step[^"]*"/);
+});
+
+test('full questionnaire path: addBuyerFirstClarity then confine', () => {
+  // Simulate mid-chain HTML: VALUE + compensation already present, no buyer-first yet
+  const mid = `<!doctype html><html><head></head><body><main>
+${VALUE_LINE}
+<form id="buyerExperienceForm" method="post" action="/api/intake">
+<section class="step active" data-title="You & this decision"><div class="eyebrow">Part 1</div><h1>Start</h1>
+<div class="submitbox"><strong>This is the moment HBE receives your information.</strong><p>x</p><button class="btn primary" type="submit">Submit to HBE</button></div>
+</section>
+<section class="step" data-title="Two"><h1>Two</h1></section>
+</form>
+${compensationPublicHtml()}
+</main></body></html>`;
+
+  let html = addBuyerFirstClarity(mid, '/questionnaire');
+  html = confineOrientationCardsToPage1(html);
+  const all = steps(html);
+  assert.ok(all.length >= 2);
+  assert.match(all[0].body, /buyer-first-core/);
+  assert.match(all[0].body, /value-context/);
+  assert.match(all[0].body, /compensation-note/);
+  assert.doesNotMatch(all[1].body, /buyer-first-core|value-context|compensation-note/);
+});
+
+test('confine falls back gracefully when steps are missing', () => {
+  const html = confineOrientationCardsToPage1(
+    `<!doctype html><html><body><main>${BUYER_CORE}${VALUE_LINE}${compensationPublicHtml()}<p>no steps</p></main></body></html>`
+  );
+  assert.match(html, /buyer-first-core/);
+  assert.match(html, /value-context/);
+  assert.match(html, /compensation-note/);
+  assert.match(html, /qx-page1-orient/);
+  assert.match(html, /no steps/);
+});
+
+test('portal VALUE panel is not mistaken for public value-context', () => {
+  const html = confineOrientationCardsToPage1(`<!doctype html><html><body><main>
+<section class="value-portal-panel"><h2>Price tells you</h2></section>
+<section class="step active"><h1>One</h1></section>
+<section class="step"><h1>Two</h1></section>
+</main></body></html>`);
+  assert.match(html, /value-portal-panel/);
+  assert.doesNotMatch(html, /qx-page1-orient/);
+  const all = steps(html);
+  assert.doesNotMatch(all[0].body, /value-portal-panel/);
+});


### PR DESCRIPTION
## Summary
MavericksATeam #48 UX cleanup: keep the three orientation education cards on Buyer Experience questionnaire **Page 1 only**, so pages 2–8 stay cleaner on iPhone.

### Before
Buyer-first (`.buyer-first-core`), VALUE (`.value-context`), and compensation (`#compensation-note`) were injected at `<main>` level outside `.step`, so they remained visible on every Continue across all 8 pages.

### After
`confineOrientationCardsToPage1()` (in outermost `issue33-production-worker.js`) extracts those three cards and re-injects them **in order** as the first children of the first `.step`:
1. HBE buyer-only (`.buyer-first-core`)
2. VALUE definition (`.value-context`)
3. Compensation education (`#compensation-note` / `.i29-comp`)

Each card gets `qx-page1-orient` for tests/CSS. Homepage `/` and `/login` injections are unchanged.

### Preserved on pages 2–8
Header, progress (x of 8 + bar), Part headings, page-specific intros, Back/Continue, privacy/consent/page-specific disclosures.

## Test plan
- [x] `node --test tests/issue48-page1-orient.test.mjs`
- [x] `node --test` on issue36 / issue29 / issue48-smoke (57/57 pass)
- [x] Live worker smoke: `/questionnaire` has all three cards inside first `.step` only; `/` still gets main-level buyer-first
- [ ] Manual iPhone check after deploy (not part of this PR)

## Notes
- No merge / no wrangler publish from this PR workstream.
- Does not change D1 isolation, no-store/noindex, Access fail-closed, MLS UNAPPROVED, or PII policy.